### PR TITLE
Vendor doc fetcher: User-Agent, retries, per-host failure counts (#223)

### DIFF
--- a/services/backend/src/api/knowledge.py
+++ b/services/backend/src/api/knowledge.py
@@ -93,6 +93,8 @@ class ReindexProgress(BaseModel):
     total_batches: int
     vendor_docs_fetched: int
     vendor_docs_total: int
+    vendor_docs_failed: int = 0
+    vendor_docs_failed_by_host: dict[str, int] = Field(default_factory=dict)
     uploads_processed: int
     uploads_total: int
 

--- a/services/backend/src/services/embedding_service.py
+++ b/services/backend/src/services/embedding_service.py
@@ -7,8 +7,10 @@ embeddings (~300MB RAM vs ~3GB for PyTorch-backed sentence-transformers).
 import asyncio
 import gc
 import os
+import random
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 import httpx
 import numpy as np
@@ -48,9 +50,67 @@ _reindex_progress: dict = {
     "total_batches": 0,
     "vendor_docs_fetched": 0,
     "vendor_docs_total": 0,
+    "vendor_docs_failed": 0,
+    "vendor_docs_failed_by_host": {},
     "uploads_processed": 0,
     "uploads_total": 0,
 }
+
+VENDOR_FETCH_USER_AGENT = os.environ.get(
+    "VENDOR_FETCH_USER_AGENT",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+)
+VENDOR_FETCH_MAX_RETRIES = int(os.environ.get("VENDOR_FETCH_MAX_RETRIES", "2"))
+VENDOR_FETCH_BACKOFF_BASE = float(os.environ.get("VENDOR_FETCH_BACKOFF_BASE", "1.0"))
+
+
+class _FetchOutcome:
+    __slots__ = ("chunks", "error", "host")
+
+    def __init__(self, chunks=None, error: str = "", host: str = "unknown"):
+        self.chunks = chunks
+        self.error = error
+        self.host = host
+
+
+async def _fetch_vendor_url(http_client: "httpx.AsyncClient", url_info: dict) -> _FetchOutcome:
+    """Fetch a single vendor doc with exponential-backoff retries for transient errors.
+
+    Transient: connection/TLS errors, read timeouts, empty 200 body, HTTP 429/5xx.
+    Permanent: 4xx other than 429, non-HTML content, parse failures. Not retried.
+    """
+    url = url_info["url"]
+    host = urlparse(url).hostname or "unknown"
+    last_err = ""
+    for attempt in range(VENDOR_FETCH_MAX_RETRIES + 1):
+        try:
+            resp = await http_client.get(url)
+            status = resp.status_code
+            if status == 200 and resp.text:
+                content_type = resp.headers.get("content-type", "")
+                if "text" in content_type or "html" in content_type:
+                    chunks = parse_vendor_doc_content(
+                        url=url,
+                        title=url_info["title"],
+                        content=resp.text,
+                    )
+                    return _FetchOutcome(chunks=chunks, host=host)
+                return _FetchOutcome(error=f"non-text content-type: {content_type}", host=host)
+            if status == 200 and not resp.text:
+                last_err = "empty body on 200"
+            elif status == 429 or 500 <= status < 600:
+                last_err = f"HTTP {status}"
+            else:
+                return _FetchOutcome(error=f"HTTP {status}", host=host)
+        except (httpx.TransportError, httpx.TimeoutException) as e:
+            last_err = f"{type(e).__name__}: {e}"
+        except Exception as e:
+            return _FetchOutcome(error=f"{type(e).__name__}: {e}", host=host)
+        if attempt < VENDOR_FETCH_MAX_RETRIES:
+            backoff = VENDOR_FETCH_BACKOFF_BASE * (2 ** attempt)
+            await asyncio.sleep(backoff + random.uniform(0, 0.25))
+    return _FetchOutcome(error=last_err or "max retries exceeded", host=host)
 
 MODEL_DIR = Path(os.environ.get("EMBEDDING_MODEL_DIR", "/app/model-cache/onnx"))
 
@@ -184,6 +244,8 @@ def _reset_progress():
         "total_batches": 0,
         "vendor_docs_fetched": 0,
         "vendor_docs_total": 0,
+        "vendor_docs_failed": 0,
+        "vendor_docs_failed_by_host": {},
         "uploads_processed": 0,
         "uploads_total": 0,
     }
@@ -342,30 +404,28 @@ async def reindex_knowledge(
             async with semaphore:
                 if _reindex_cancelled:
                     return
-                try:
-                    resp = await http_client.get(url_info["url"])
-                    if resp.status_code == 200:
-                        content_type = resp.headers.get("content-type", "")
-                        if "text" in content_type or "html" in content_type:
-                            doc_chunks = parse_vendor_doc_content(
-                                url=url_info["url"],
-                                title=url_info["title"],
-                                content=resp.text,
-                            )
-                            async with vendor_lock:
-                                vendor_chunks.extend(doc_chunks)
-                                vendor_doc_count += 1
-                                _reindex_progress["vendor_docs_fetched"] = vendor_doc_count
-                except Exception as e:
-                    async with vendor_lock:
-                        errors.append(f"Failed to fetch {url_info['url']}: {e}")
-                    logger.warning(
-                        "Failed to fetch vendor doc",
-                        url=url_info["url"],
-                        error=str(e),
-                    )
+                outcome = await _fetch_vendor_url(http_client, url_info)
+                async with vendor_lock:
+                    if outcome.chunks is not None:
+                        vendor_chunks.extend(outcome.chunks)
+                        vendor_doc_count += 1
+                        _reindex_progress["vendor_docs_fetched"] = vendor_doc_count
+                    else:
+                        errors.append(f"Failed to fetch {url_info['url']}: {outcome.error}")
+                        _reindex_progress["vendor_docs_failed"] += 1
+                        by_host = _reindex_progress["vendor_docs_failed_by_host"]
+                        by_host[outcome.host] = by_host.get(outcome.host, 0) + 1
+                        logger.warning(
+                            "Failed to fetch vendor doc",
+                            url=url_info["url"],
+                            error=outcome.error,
+                        )
 
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as http_client:
+        async with httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=True,
+            headers={"User-Agent": VENDOR_FETCH_USER_AGENT},
+        ) as http_client:
             tasks = [_fetch_one(http_client, url_info) for url_info in vendor_urls]
             await asyncio.gather(*tasks)
 

--- a/services/backend/tests/test_vendor_fetcher.py
+++ b/services/backend/tests/test_vendor_fetcher.py
@@ -1,0 +1,93 @@
+"""Tests for the vendor doc fetcher — User-Agent, retry, per-host failure counts (#223)."""
+import os
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+os.environ.setdefault("VENDOR_FETCH_BACKOFF_BASE", "0")
+
+from src.services import embedding_service  # noqa: E402
+from src.services.embedding_service import _fetch_vendor_url  # noqa: E402
+
+
+def _ok(body: str = "<html>ok</html>") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = body
+    resp.headers = {"content-type": "text/html; charset=utf-8"}
+    return resp
+
+
+def _status(status: int, body: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = body
+    resp.headers = {"content-type": "text/html"}
+    return resp
+
+
+class _FakeClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    async def get(self, url):
+        self.calls.append(url)
+        r = self._responses.pop(0)
+        if isinstance(r, Exception):
+            raise r
+        return r
+
+
+def test_default_user_agent_is_browser_shaped():
+    """Default User-Agent must not be the httpx default (vendors block it)."""
+    ua = embedding_service.VENDOR_FETCH_USER_AGENT
+    assert "Mozilla" in ua and "Chrome" in ua
+
+
+@pytest.mark.asyncio
+async def test_retries_on_transient_error_then_succeeds():
+    client = _FakeClient([httpx.ConnectError("reset"), _ok()])
+    outcome = await _fetch_vendor_url(client, {"url": "https://example.com/a", "title": "A"})
+    assert outcome.chunks is not None
+    assert outcome.error == ""
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_retries_on_5xx_then_succeeds():
+    client = _FakeClient([_status(503), _ok()])
+    outcome = await _fetch_vendor_url(client, {"url": "https://example.com/a", "title": "A"})
+    assert outcome.chunks is not None
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_retries_on_empty_200_body():
+    """Empty 200 body is the WAF-block signature — should retry."""
+    client = _FakeClient([_status(200, ""), _ok()])
+    outcome = await _fetch_vendor_url(client, {"url": "https://www.hpe.com/a", "title": "A"})
+    assert outcome.chunks is not None
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_on_404():
+    client = _FakeClient([_status(404)])
+    outcome = await _fetch_vendor_url(
+        client, {"url": "https://example.com/missing", "title": "X"}
+    )
+    assert outcome.chunks is None
+    assert "404" in outcome.error
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_records_host_on_persistent_failure():
+    errors = [httpx.ConnectError("blocked")] * (embedding_service.VENDOR_FETCH_MAX_RETRIES + 1)
+    client = _FakeClient(errors)
+    outcome = await _fetch_vendor_url(client, {"url": "https://www.hpe.com/a", "title": "A"})
+    assert outcome.chunks is None
+    assert outcome.host == "www.hpe.com"
+    assert len(client.calls) == embedding_service.VENDOR_FETCH_MAX_RETRIES + 1

--- a/specs/architecture/knowledge-embeddings.md
+++ b/specs/architecture/knowledge-embeddings.md
@@ -45,6 +45,14 @@ knowledge/
 
 Background task controls: cancel, pause, resume, timeout (default 5 minutes).
 
+### Vendor Doc Fetcher
+
+The vendor doc fetcher retrieves pages referenced in `## Reference Links` sections and indexes their extracted text alongside the knowledge files themselves.
+
+- **User-Agent:** Requests are sent with a browser-style `User-Agent` string. The default httpx UA is blocked by common anti-bot protections (Akamai, Cloudflare bot-fight, and aggressively on `hpe.com`). The UA is configurable via `VENDOR_FETCH_USER_AGENT` for debugging.
+- **Retry policy:** Transient failures (connection reset, read timeout, empty body on a 200 response, HTTP 429/5xx) are retried with exponential backoff up to `VENDOR_FETCH_MAX_RETRIES` attempts (default 2 retries, so 3 total attempts). Permanent failures (404, DNS failure) are not retried.
+- **Failure visibility:** The reindex status response exposes both total failure counts and per-host failure counts in `progress.vendor_docs_failed` and `progress.vendor_docs_failed_by_host`. This lets operators detect vendor-side blocking patterns without having to grep the errors array.
+
 ### Search (`POST /api/v1/knowledge/search`)
 
 1. Generate embedding for the query text


### PR DESCRIPTION
## Summary
- Browser-style `User-Agent` by default (the httpx default is blocked by `hpe.com` and similar WAF-protected hosts). Overridable via `VENDOR_FETCH_USER_AGENT`.
- Exponential-backoff retry for transient errors (connection/TLS, timeout, empty 200 body, HTTP 429/5xx). Permanent failures (404, non-text) are not retried. Configurable via `VENDOR_FETCH_MAX_RETRIES` (default 2 retries = 3 attempts).
- `vendor_docs_failed` and `vendor_docs_failed_by_host` surfaced in `/knowledge/reindex/status` so persistent vendor-side blocks are visible without grepping the errors array.
- `_fetch_vendor_url` helper extracted to make the retry and classification logic directly testable. 6 focused unit tests cover UA, transient retry, 5xx retry, empty-body retry, 404 no-retry, and host tracking.

Closes #223

## Test plan
- [x] `pytest tests/test_vendor_fetcher.py` — 6 passed
- [x] Full backend suite (157 passed)
- [x] `ruff check` passes on changed files
- [ ] Post-merge: rebuild backend image, redeploy, trigger reindex; confirm HPE URLs now index and `vendor_docs_failed_by_host` shows any residual blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)