### PR TITLE
Knowledge: backfill reverse See Also cross-references (#287)

### DIFF
--- a/knowledge/general/cost.md
+++ b/knowledge/general/cost.md
@@ -88,3 +88,4 @@ FinOps — the practice of bringing financial accountability to cloud spending �
 - `general/observability.md` — Monitoring and observability including cost metric dashboards
 - `general/finops.md` — FinOps practices, frameworks, tooling, and organizational cost management at scale
 - `general/cost-onprem.md` — On-premises cost modeling, TCO analysis, hardware depreciation, and cloud comparison frameworks
+- `patterns/vmware-servicenow-chargeback.md` — VMware-specific chargeback integration pattern

--- a/knowledge/general/finops.md
+++ b/knowledge/general/finops.md
@@ -119,3 +119,4 @@ Commitment discounts represent the single largest optimization lever, offering 3
 - `general/container-orchestration.md` — Kubernetes resource management and cluster design
 - `general/observability.md` — Monitoring and dashboards including cost metric instrumentation
 - `general/compute.md` — Instance type selection, right-sizing, and auto-scaling strategies
+- `patterns/vmware-servicenow-chargeback.md` — VMware-specific chargeback integration pattern

--- a/knowledge/providers/ibm/powervs.md
+++ b/knowledge/providers/ibm/powervs.md
@@ -91,3 +91,4 @@ Migration tooling for Power is its own discipline. There is no equivalent of AWS
 - `general/workload-migration.md` -- migration wave methodology and cutover planning
 - `general/disaster-recovery.md` -- DR architecture patterns including replication-based and snapshot-based DR
 - `general/enterprise-backup.md` -- enterprise backup tooling that targets PowerVS as a source or destination
+- `providers/ibm/power-onprem.md` -- on-prem foundation

--- a/knowledge/providers/servicenow/itsm.md
+++ b/knowledge/providers/servicenow/itsm.md
@@ -66,6 +66,7 @@ ServiceNow's AI integration layer consists of two components:
 - `general/managed-services-scoping.md` -- managed services scope definition and ITSM boundary decisions
 - `general/ai-ml-services.md` -- cross-provider AI service strategy (model selection, RAG, cost patterns)
 - `providers/azure/ai-ml-services.md` -- Azure OpenAI (common LLM backend for Now Assist)
+- `patterns/vmware-servicenow-chargeback.md` -- VMware-specific chargeback integration pattern
 
 ## Reference Links
 

--- a/knowledge/providers/skytap/cloud.md
+++ b/knowledge/providers/skytap/cloud.md
@@ -90,3 +90,5 @@ The recurring-billing trap deserves explicit callout because it is operationally
 - `general/workload-migration.md` -- migration wave methodology and cutover planning
 - `general/disaster-recovery.md` -- DR architecture patterns including replication-based DR
 - `providers/hystax/migration.md` -- third-party migration tooling that can target Skytap for x86 sources
+- `providers/ibm/powervs.md` -- IBM-hosted alternative to Skytap
+- `providers/ibm/power-onprem.md` -- on-prem foundation for both Skytap and PowerVS migrations

--- a/knowledge/providers/vmware/aria-suite.md
+++ b/knowledge/providers/vmware/aria-suite.md
@@ -78,3 +78,4 @@ Finally, the deployment-model question (on-prem vs SaaS vs hybrid) has changed c
 - `providers/morpheus/cloud-management.md` -- Morpheus as a CMP alternative to VCF Automation under Broadcom renewal pressure
 - `providers/prometheus-grafana/observability.md` -- Prometheus + Grafana as an alternative to VCF Operations for VMware observability
 - `providers/hashicorp/terraform.md` -- Terraform as an IaC alternative to VCF Automation for VM and infrastructure provisioning
+- `patterns/vmware-servicenow-chargeback.md` -- VMware-specific chargeback integration pattern

--- a/knowledge/providers/vmware/observability.md
+++ b/knowledge/providers/vmware/observability.md
@@ -49,3 +49,4 @@ VMware environments degrade silently. CPU ready time above 5% indicates VMs are 
 - `providers/vmware/infrastructure.md` -- VMware infrastructure and lifecycle management
 - `providers/vmware/storage.md` -- vSAN health monitoring
 - `providers/prometheus-grafana/observability.md` -- Prometheus/Grafana for external VMware monitoring
+- `providers/vmware/aria-suite.md` -- unified suite-level treatment, licensing, deployment model

--- a/knowledge/providers/vmware/platform-services.md
+++ b/knowledge/providers/vmware/platform-services.md
@@ -75,3 +75,4 @@ VMware's platform services transform vSphere from a virtualization layer into a 
 - `providers/vmware/vcf-sddc-manager.md` -- VCF lifecycle and SDDC Manager
 - `providers/vmware/vmc-aws.md` -- VMC on AWS hybrid cloud
 - `providers/vmware/avs-azure.md` -- AVS hybrid cloud
+- `providers/vmware/aria-suite.md` -- unified suite-level treatment, licensing, deployment model


### PR DESCRIPTION
## Summary

Mechanical backfill: adds reverse See Also entries from existing component-level knowledge files into the newly-merged provider/pattern files so the cross-reference graph is bidirectional.

Edits per issue #287:
- `providers/vmware/observability.md` -> aria-suite
- `providers/vmware/platform-services.md` -> aria-suite
- `general/finops.md` -> vmware-servicenow-chargeback
- `general/cost.md` -> vmware-servicenow-chargeback
- `providers/servicenow/itsm.md` -> vmware-servicenow-chargeback
- `providers/vmware/aria-suite.md` -> vmware-servicenow-chargeback
- `providers/skytap/cloud.md` -> ibm/powervs + ibm/power-onprem
- `providers/ibm/powervs.md` -> ibm/power-onprem (skytap already present)
- `providers/ibm/power-onprem.md` -> no-op (both target entries already present; idempotent skip)

No content edits beyond See Also lines. No nav changes.

Closes #287

## Test plan

- [x] `scripts/check-nav.sh` passes
- [x] Each modified See Also section retains its original separator style (`--` or em-dash)
- [x] No duplicate entries introduced