### PR TITLE
chore: ignore local test/agent artifacts that show as untracked noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,11 @@ node_modules/
 # Test artifacts
 .pytest_cache/
 .coverage
+.coverage.*
 htmlcov/
 coverage/
+test.db
+*.sqlite3
 
 # TLS certificates
 *.pem
@@ -58,3 +61,9 @@ Thumbs.db
 
 # Docker
 *.tar
+
+# Agent workspace
+.claude/
+
+# Sibling repo cloned in-tree for local MCP work (has its own remote)
+architect-knowledge-mcp/


### PR DESCRIPTION
Four items showed as untracked in every `git status`, which trains you to skim the output — the habit that let 51 unpushed commits sit in a sibling repo for nine days.

| item | why it wasn't ignored |
|---|---|
| `.coverage.*` | pytest-cov writes `.coverage.<host>.<pid>.<rand>`; the existing `.coverage` rule is a literal filename and doesn't match |
| `test.db`, `*.sqlite3` | local backend test database |
| `.claude/` | agent workspace |
| `architect-knowledge-mcp/` | sibling repo cloned in-tree for local MCP work — has its own remote, must not be committed here |

## Verification

- all four now report `IGNORED` via `git check-ignore`
- `git ls-files -i -c --exclude-standard` is **empty** — no already-tracked file becomes invisible
- `git status` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)