### PR TITLE
fix(db): remove the inline DB password from alembic.ini (#312)

### DIFF
--- a/.githooks/client-patterns.local.example
+++ b/.githooks/client-patterns.local.example
@@ -1,0 +1,19 @@
+# TEMPLATE — copy to `client-patterns.local` and fill in.
+#
+#   cp .githooks/client-patterns.local.example .githooks/client-patterns.local
+#
+# `client-patterns.local` is GITIGNORED and must stay that way. This repo is
+# PUBLIC, so committing the real list would publish exactly the names the hook
+# exists to keep out — the guard would become the leak.
+#
+# One case-insensitive extended-regex per line. `\b` gives word boundaries so a
+# short name does not match inside unrelated words. Blank lines and #-comments
+# are ignored.
+#
+# Cover, for each engagement: company name, common abbreviations and former
+# names, site/campus names, and any internal system name that is not a public
+# product.
+
+\bExampleCorp\b
+\bExmplCo\b
+\bNorthCampus\b

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# .githooks/commit-msg — the message itself must not carry client data or
+# credentials. Separate from pre-commit because pre-commit runs BEFORE the message
+# is written, so COMMIT_EDITMSG still holds the PREVIOUS commit's text there.
+set -uo pipefail
+. "$(dirname "$0")/guard-lib.sh"
+
+MSG="$(cat "$1")"
+FAILED=0
+client_regex >/dev/null 2>&1 || warn_missing_client_patterns
+
+# No knowledge/mkdocs exemption applies to a commit message — nothing about a
+# message needs to name a vendor that collides with a client.
+scan_text_for_client_data "commit message" "$MSG" || FAILED=1
+scan_text_for_credentials "commit message" "$MSG" || FAILED=1
+
+if [ "$FAILED" -eq 1 ]; then
+  printf '\n%s\n' "${RED}Commit message rejected.${NC}" >&2
+  printf '%s\n' "  False positive? ${YEL}git commit --no-verify${NC} (verify first)." >&2
+  exit 1
+fi
+exit 0

--- a/.githooks/credential-allowlist
+++ b/.githooks/credential-allowlist
@@ -1,0 +1,10 @@
+# Accepted credential-scan findings, keyed by `<path>:<sha256 of the matched line>`.
+# A line hash rather than a whole-file exemption: editing the line re-flags it, so
+# this cannot silently cover a real key added to the same file later.
+#
+# Versioned on purpose — an accepted finding is by definition not a secret.
+# Add an entry ONLY with a comment saying why it is safe.
+#
+# Documentation placeholder in the knowledge library; `prod-password` is illustrative
+# Pulumi config, not a value. (knowledge/providers/pulumi/iac.md)
+knowledge/providers/pulumi/iac.md:d3036ac304303c69401901ec297a5794cb07855fa8ee1747dbd4774c495a8279

--- a/.githooks/guard-lib.sh
+++ b/.githooks/guard-lib.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Shared guard library for .githooks/{pre-commit,commit-msg}.
+#
+# THIS REPO IS PUBLIC. Two classes of leak matter, and they need DIFFERENT scan
+# scopes — which is the whole reason this library exists rather than one flat list:
+#
+#   CLIENT DATA  — client/site/system names. Scanned everywhere EXCEPT
+#                  `knowledge/**` and `mkdocs.yml`, because a vendor in the
+#                  79-vendor knowledge library legitimately collides with a client
+#                  name, and without the exemption every library commit would be
+#                  blocked. Patterns are confidential and live in the GITIGNORED
+#                  `client-patterns.local` (see the .example).
+#
+#   CREDENTIALS  — keys, tokens, private keys. Scanned in EVERY file, with NO
+#                  exemptions. A leaked AWS key inside a knowledge doc is exactly
+#                  as compromised as one in source, and unlike vendor names there
+#                  is no false-positive reason to exempt anything. The previous
+#                  hooks had ZERO credential patterns, which left the only PUBLIC
+#                  repo of the three with the weakest guard of the three.
+#
+# Also fixes a maintenance hazard: the old `.git/hooks/pre-commit` and
+# `.git/hooks/commit-msg` each carried their own copy of the pattern list, so
+# editing one silently left the other stale.
+#
+# Activate with:  git config core.hooksPath .githooks   (per-clone; hook paths are
+# not versioned, so a fresh clone has NO guard until this is run).
+
+set -uo pipefail
+
+RED=$'\033[31m'; YEL=$'\033[33m'; GRN=$'\033[32m'; DIM=$'\033[2m'; NC=$'\033[0m'
+
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLIENT_PATTERNS_FILE="$HOOKS_DIR/client-patterns.local"
+
+# ---------- credential patterns (versioned; safe to publish) ----------
+# Shapes only — no secret is embedded here.
+CRED_PATTERNS=(
+  '\b(AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b'                    # AWS access key id
+  '(aws_secret_access_key|aws_session_token)[[:space:]]*[:=]' # AWS secret assignment
+  '\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b'               # GitHub token
+  '\bgithub_pat_[A-Za-z0-9_]{50,}\b'                         # GitHub fine-grained PAT
+  '\bxox[baprs]-[0-9A-Za-z-]{10,}\b'                         # Slack
+  '\b(sk|rk)_live_[0-9A-Za-z]{20,}\b'                        # Stripe live
+  '\bAIza[0-9A-Za-z_-]{35}\b'                                # Google API key
+  '\bsk-ant-[A-Za-z0-9_-]{20,}\b'                            # Anthropic
+  '\bsk-[A-Za-z0-9]{48}\b'                                   # OpenAI
+  '\bnpm_[A-Za-z0-9]{36}\b'                                  # npm
+  '\bpypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{20,}'                 # PyPI
+  '\bglpat-[A-Za-z0-9_-]{20,}\b'                             # GitLab PAT
+  '\bdop_v1_[a-f0-9]{64}\b'                                  # DigitalOcean
+  '-----BEGIN( RSA| EC| DSA| OPENSSH| PGP)? PRIVATE KEY'     # private key block
+  '\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}'  # JWT
+  '(password|passwd|secret|api[_-]?key|apikey|access[_-]?token|auth[_-]?token|client[_-]?secret)[[:space:]]*[:=][[:space:]]*["'"'"'][^"'"'"'[:space:]]{12,}["'"'"']'
+  # Inline password in a connection URI. Requires >=8 chars and excludes shell/k8s
+  # substitutions via CRED_BENIGN — `postgres://u:$(PGPASSWORD)@h` is how this repo
+  # legitimately writes them, and flagging that would block every k8s manifest.
+  '(postgres|postgresql|mysql|mongodb|redis|amqp|amqps)(\+[a-z]+)?://[^:@/[:space:]]+:[^@/[:space:]]{8,}@'
+)
+
+# NOTE: every grep below passes the pattern via `-e`. The private-key pattern
+# starts with `-----`, which grep parses as options otherwise — that pattern
+# silently never matched until a branch test caught it.
+
+# Values that match a credential shape but are demonstrably not secrets. Kept
+# tight on purpose: a permissive allowlist is how a real key slips through.
+# `\$[A-Za-z_]` covers a BARE shell variable — `password="$POSTGRES_PASSWORD"` is
+# how scripts/create-secrets.sh correctly avoids embedding a secret, and flagging
+# it would train a --no-verify habit. `(prod|dev|staging)[-_]password` covers the
+# documentation placeholders the knowledge library uses.
+CRED_BENIGN='(changeme|placeholder|example|redacted|dummy|sample|your[_-]|xxxx|\$\{|\$\(|\$[A-Za-z_]|<[A-Za-z_]|notarealsecret|fake|test[_-]?(key|token|secret)|(prod|dev|staging|local)[-_]password|ENC\[|\*{4,})'
+
+# ---------- allowlist for ACCEPTED pre-existing findings ----------
+# Keyed by `<path>:<sha256 of the matched line>`, so editing the line re-flags it.
+# A whole-file exemption would silently cover a real key added later; a line hash
+# cannot. Versioned deliberately — an accepted finding is by definition not secret.
+ALLOWLIST_FILE="$HOOKS_DIR/credential-allowlist"
+
+is_allowlisted() {  # is_allowlisted <path> <line-text>
+  [ -f "$ALLOWLIST_FILE" ] || return 1
+  local key
+  key="$1:$(printf '%s' "$2" | sha256sum | cut -d' ' -f1)"
+  grep -qxF "$key" "$ALLOWLIST_FILE" 2>/dev/null
+}
+
+# ---------- forbidden paths ----------
+FORBIDDEN_PATHS=(
+  '(^|/)\.env$'  '(^|/)\.env\.[^/]+$'  '(^|/)credentials\.json$'
+  '(^|/)kubeconfig(\.ya?ml)?$'  '(^|/)id_(rsa|dsa|ecdsa|ed25519)$'
+  '\.pem$' '\.p12$' '\.pfx$' '\.jks$' '\.keystore$'
+  '(^|/)service-account.*\.json$'  '(^|/)\.npmrc$'  '(^|/)\.pypirc$'
+  '(^|/)terraform\.tfstate(\.backup)?$'  '(^|/)secrets?\.ya?ml$'
+)
+
+# ---------- helpers ----------
+
+# Client patterns are OPTIONAL-but-warned: a missing file must not silently
+# disable the client-data guard, which is this repo's #1 rule.
+client_regex() {
+  if [ ! -f "$CLIENT_PATTERNS_FILE" ]; then
+    printf '%s' ""
+    return 1
+  fi
+  grep -vE '^\s*(#|$)' "$CLIENT_PATTERNS_FILE" | paste -sd'|' -
+}
+
+warn_missing_client_patterns() {
+  printf '%s\n' "${YEL}WARNING: $CLIENT_PATTERNS_FILE is missing — the CLIENT-DATA guard is OFF.${NC}" >&2
+  printf '%s\n' "${DIM}  cp .githooks/client-patterns.local.example .githooks/client-patterns.local${NC}" >&2
+  printf '%s\n' "${DIM}  Credential scanning still applies. This repo is PUBLIC; do not commit${NC}" >&2
+  printf '%s\n' "${DIM}  engagement content until the client list is in place.${NC}" >&2
+}
+
+# is_exempt_from_client_scan <path>
+# knowledge/** and mkdocs.yml only. Credential scanning never consults this.
+is_exempt_from_client_scan() {
+  case "$1" in
+    knowledge/*|mkdocs.yml) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# scan_text_for_credentials <label> <text>  -> 0 clean, 1 hit
+scan_text_for_credentials() {
+  local label="$1" text="$2" pat hits rc=0
+  for pat in "${CRED_PATTERNS[@]}"; do
+    hits="$(printf '%s' "$text" | grep -inE -e "$pat" 2>/dev/null | grep -ivE -e "$CRED_BENIGN" || true)"
+    [ -z "$hits" ] && continue
+    # Drop lines whose exact content is allowlisted for this path.
+    local kept="" line body
+    while IFS= read -r line; do
+      body="${line#*:}"
+      is_allowlisted "$label" "$body" || kept="${kept}${line}"$'\n'
+    done <<< "$hits"
+    if [ -n "${kept//[$'\n\t ']/}" ]; then
+      printf '%s\n' "${RED}BLOCKED: possible CREDENTIAL in $label${NC}" >&2
+      printf '%s\n' "$kept" | grep -v '^$' | head -3 | sed 's/^/    /' >&2
+      rc=1
+    fi
+  done
+  return $rc
+}
+
+# scan_text_for_client_data <label> <text>  -> 0 clean, 1 hit
+# Prints line numbers and a redacted marker, never the matched name — a hook
+# transcript is less protected than the pattern file.
+scan_text_for_client_data() {
+  local label="$1" text="$2" combined hits
+  combined="$(client_regex)" || return 0
+  [ -z "$combined" ] && return 0
+  hits="$(printf '%s' "$text" | grep -inE -e "$combined" 2>/dev/null || true)"
+  if [ -n "$hits" ]; then
+    printf '%s\n' "${RED}BLOCKED: possible CLIENT DATA in $label${NC}" >&2
+    printf '%s\n' "$hits" | head -5 | cut -d: -f1 \
+      | sed 's/^/    line /;s/$/: [redacted — matched a confidential client pattern]/' >&2
+    return 1
+  fi
+  return 0
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit — block client data AND credentials before they reach a
+# PUBLIC repo. See .githooks/guard-lib.sh for why the two classes have different
+# scan scopes.
+#
+# Bypass with `git commit --no-verify` if a finding is genuinely a false positive
+# — but verify first. This repo is public; a committed secret is compromised the
+# moment it is pushed, and rotation is the only remedy.
+set -uo pipefail
+. "$(dirname "$0")/guard-lib.sh"
+
+FAILED=0
+client_regex >/dev/null 2>&1 || warn_missing_client_patterns
+
+# ---------- 1. forbidden paths ----------
+while IFS= read -r -d '' file; do
+  for pat in "${FORBIDDEN_PATHS[@]}"; do
+    if printf '%s' "$file" | grep -qE "$pat"; then
+      case "$file" in *.example|*.sample|*.template) continue ;; esac
+      printf '%s\n' "${RED}BLOCKED: forbidden path staged: $file${NC}" >&2
+      FAILED=1
+    fi
+  done
+done < <(git diff --cached --name-only -z --diff-filter=d)
+
+# ---------- 2. staged content ----------
+while IFS= read -r -d '' file; do
+  # Binary guard FIRST, and via git rather than a shell string test. An earlier
+  # draft used `case "$CONTENT" in *$'\0'*)`, but bash cannot hold NUL in a
+  # variable so $'\0' collapses to the empty string, the pattern degenerates to
+  # `**`, and EVERY file was skipped as binary — the content scan silently ran on
+  # nothing. Caught only by testing the branch.
+  # `--numstat` prints "-\t-" for binary blobs.
+  if git diff --cached --numstat -- "$file" | head -1 | grep -q '^-'"$(printf '\t')"'-'; then
+    continue
+  fi
+  CONTENT="$(git show ":$file" 2>/dev/null || true)"
+  [ -z "$CONTENT" ] && continue
+
+  # CREDENTIALS — every file, no exemptions. A key in a knowledge doc is just as
+  # leaked as one in source.
+  scan_text_for_credentials "$file" "$CONTENT" || FAILED=1
+
+  # CLIENT DATA — everywhere except knowledge/** and mkdocs.yml, where the
+  # 79-vendor library legitimately collides with client names.
+  if ! is_exempt_from_client_scan "$file"; then
+    scan_text_for_client_data "$file" "$CONTENT" || FAILED=1
+  fi
+done < <(git diff --cached --name-only -z --diff-filter=d)
+
+if [ "$FAILED" -eq 1 ]; then
+  printf '\n%s\n' "${RED}Commit rejected.${NC}" >&2
+  printf '%s\n' "  Client data and credentials must never enter this repo — it is PUBLIC." >&2
+  printf '%s\n' "  False positive? ${YEL}git commit --no-verify${NC} (verify first)." >&2
+  exit 1
+fi
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ Thumbs.db
 
 # Sibling repo cloned in-tree for local MCP work (has its own remote)
 architect-knowledge-mcp/
+
+# Confidential client-name patterns for the git hooks (see .example)
+.githooks/client-patterns.local

--- a/db/alembic.ini
+++ b/db/alembic.ini
@@ -1,6 +1,11 @@
 [alembic]
 script_location = db/alembic
-sqlalchemy.url = postgresql://architect:architect-dev@postgres:5432/architect
+# sqlalchemy.url is deliberately NOT set here (#312). It previously carried an
+# inline password, and this repo is PUBLIC. Nothing in any deployment path read
+# it: db/alembic/env.py sets the URL from $DATABASE_URL, and
+# k8s/base/migration-job.yaml always supplies it from the secret. env.py now
+# fails with an explicit message if DATABASE_URL is absent, which is better than
+# silently connecting to a hardcoded default.
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/db/alembic/env.py
+++ b/db/alembic/env.py
@@ -11,10 +11,20 @@ if config.config_file_name is not None:
 
 target_metadata = None
 
-# Override URL from environment variable if set
-database_url = os.environ.get("DATABASE_URL")
-if database_url:
-    config.set_main_option("sqlalchemy.url", database_url)
+# DATABASE_URL is the ONLY source of the connection URL (#312). alembic.ini used to
+# carry a fallback with an inline password; in a public repo that is a committed
+# credential, and nothing read it — every deployment path sets DATABASE_URL from a
+# secret. Failing explicitly here beats connecting to a hardcoded default, and beats
+# the opaque `None`-typed error alembic would otherwise raise several frames later.
+database_url = os.environ.get("DATABASE_URL") or config.get_main_option("sqlalchemy.url")
+if not database_url:
+    raise RuntimeError(
+        "DATABASE_URL is not set and alembic.ini defines no sqlalchemy.url.\n"
+        "Set it before running migrations, e.g.\n"
+        "  export DATABASE_URL='postgresql://architect:<password>@localhost:5432/architect'\n"
+        "In-cluster this is supplied by k8s/base/migration-job.yaml from the secret."
+    )
+config.set_main_option("sqlalchemy.url", database_url)
 
 
 def run_migrations_offline() -> None:


### PR DESCRIPTION
Closes #312. The only genuine finding from scanning all 585 tracked text files with the new guard (#311).

`db/alembic.ini:3` committed an inline password to a **public** repo:

```ini
sqlalchemy.url = postgresql://architect:<REDACTED>@postgres:5432/architect
```

## It was a dead fallback

`db/alembic/env.py` already preferred `$DATABASE_URL`, and `k8s/base/migration-job.yaml` always supplies it from the secret via `$(PGPASSWORD)`. **No deployment path ever read the literal** — it applied only to a bare local `alembic` run with no `DATABASE_URL` exported.

## Changes

- **`alembic.ini`** — `sqlalchemy.url` removed, with a comment recording *why*, so it doesn't get helpfully restored.
- **`env.py`** — `DATABASE_URL` is now the only source, and its absence raises an explicit `RuntimeError` naming the variable with an example export. Previously a missing URL surfaced as an opaque `None`-typed failure several frames into alembic. Failing loudly also beats silently connecting to a hardcoded default, which is what the old fallback did.

## Not allowlisted, deliberately

`.githooks/credential-allowlist` exists, and using it here would have been wrong. Allowlisting a real credential because it's weak is how that habit starts, and the password being dev-only doesn't change that a public repo should carry no credential-shaped literals.

## Verification

| case | result |
|---|---|
| `DATABASE_URL` unset | `RuntimeError` with the actionable message |
| `DATABASE_URL` set | config accepted, proceeds to connect (fails only on missing local `psycopg2`, i.e. past the config layer) |
| `alembic.ini` parses | yes, `sqlalchemy.url` absent as intended |
| pre-commit on `alembic.ini` | no longer blocks |
| whole-tree credential rescan | **0 findings** (was 1) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
