### PR TITLE
fix(knowledge): repair 97 dead external links across 66 files

### DIFF
--- a/knowledge/compliance/ccpa.md
+++ b/knowledge/compliance/ccpa.md
@@ -273,7 +273,7 @@ Numerous US states have enacted comprehensive privacy laws modeled on the CCPA/C
 - [CCPA Full Text (California Legislative Information)](https://leginfo.legislature.ca.gov/faces/codes_displayText.xhtml?division=3.&part=4.&lawCode=CIV&title=1.81.5) — official statutory text of Civil Code 1798.100-1798.199.100
 - [CPRA Ballot Initiative Text (Proposition 24)](https://vig.cdn.sos.ca.gov/2020/general/pdf/topl-prop24.pdf) — full text of the CPRA as approved by California voters in November 2020
 - [CPPA Official Regulations](https://cppa.ca.gov/regulations/) — California Privacy Protection Agency regulations implementing the CCPA/CPRA
-- [CPPA Enforcement Actions](https://cppa.ca.gov/enforcement/) — published enforcement actions and case summaries
+- [CPPA News & Announcements](https://cppa.ca.gov/announcements/) — published enforcement decisions, orders, and settlements, plus regulatory updates
 - [California Attorney General CCPA Page](https://oag.ca.gov/privacy/ccpa) — Attorney General guidance and resources on CCPA compliance
 - [Global Privacy Control Specification](https://globalprivacycontrol.org/) — technical specification for the GPC browser signal that must be honored under CPRA
 

--- a/knowledge/compliance/dora.md
+++ b/knowledge/compliance/dora.md
@@ -124,7 +124,7 @@ For critical third-party providers, the EU-level oversight can also impose remed
 ## Reference Links
 
 - [Regulation (EU) 2022/2554 (DORA official text)](https://eur-lex.europa.eu/eli/reg/2022/2554/oj)
-- [ESA technical standards under DORA](https://www.eba.europa.eu/regulation-and-policy/operational-resilience-cyber-security)
+- [EBA: Digital Operational Resilience Act -- adopted ESA joint technical standards (RTS/ITS)](https://www.eba.europa.eu/activities/direct-supervision-and-oversight/digital-operational-resilience-act)
 - [TIBER-EU framework (DORA reference for TLPT)](https://www.ecb.europa.eu/paym/cyber-resilience/tiber-eu/html/index.en.html)
 
 ## See Also

--- a/knowledge/compliance/glba.md
+++ b/knowledge/compliance/glba.md
@@ -111,7 +111,7 @@ The 2023 amendment added breach notification requirements: financial institution
 - [FTC Safeguards Rule (16 CFR Part 314)](https://www.ftc.gov/legal-library/browse/rules/safeguards-rule)
 - [FTC Privacy Rule (16 CFR Part 313)](https://www.ftc.gov/legal-library/browse/rules/financial-privacy-rule)
 - [Federal banking agency interagency guidelines](https://www.fdic.gov/resources/supervision-and-examinations/consumer-compliance-examination-manual/documents/8/viii-1-1.pdf)
-- [FTC Safeguards Rule Final Rule (2021 amendment)](https://www.ftc.gov/news-events/news/press-releases/2021/10/ftc-strengthens-security-safeguards-consumer-financial-information)
+- [FTC Safeguards Rule Final Rule (2021 amendment)](https://www.ftc.gov/news-events/news/press-releases/2021/10/ftc-strengthens-security-safeguards-consumer-financial-information-following-widespread-data)
 
 ## See Also
 

--- a/knowledge/compliance/hipaa.md
+++ b/knowledge/compliance/hipaa.md
@@ -553,7 +553,7 @@ GCP maintains a list of HIPAA-covered services:
 ## Reference Links
 
 - [HHS HIPAA Security Rule](https://www.hhs.gov/hipaa/for-professionals/security/index.html) — official Security Rule guidance from the U.S. Department of Health and Human Services
-- [NIST SP 800-66](https://csrc.nist.gov/publications/detail/sp/800-66/rev-2/final) — implementing the HIPAA Security Rule: a cybersecurity resource guide
+- [NIST SP 800-66](https://csrc.nist.gov/pubs/sp/800/66/r2/final) — implementing the HIPAA Security Rule: a cybersecurity resource guide
 - [HHS Breach Portal](https://ocrportal.hhs.gov/ocr/breach/breach_report.jsf) — public database of HIPAA breach reports affecting 500 or more individuals
 - [AWS HIPAA](https://aws.amazon.com/compliance/hipaa-compliance/) — AWS HIPAA compliance program, BAA information, and eligible services
 - [Azure HIPAA](https://learn.microsoft.com/en-us/azure/compliance/offerings/offering-hipaa-us) — Azure HIPAA/HITRUST compliance documentation and BAA coverage

--- a/knowledge/compliance/hitrust-csf.md
+++ b/knowledge/compliance/hitrust-csf.md
@@ -110,7 +110,7 @@ The reverse is not true — a HIPAA risk analysis is not equivalent to a HITRUST
 
 - [HITRUST Alliance](https://hitrustalliance.net/)
 - [HITRUST CSF](https://hitrustalliance.net/product-tool/hitrust-csf/)
-- [HITRUST e1, i1, r2 assessment levels](https://hitrustalliance.net/product-tool/assessments/)
+- [HITRUST e1, i1, r2 assessment levels](https://hitrustalliance.net/assessments-and-certifications)
 - [AWS HITRUST eligibility](https://aws.amazon.com/compliance/hitrust/)
 - [Azure HITRUST guidance](https://learn.microsoft.com/azure/compliance/offerings/offering-hitrust)
 - [GCP HITRUST guidance](https://cloud.google.com/security/compliance/hitrust)

--- a/knowledge/compliance/nerc-cip.md
+++ b/knowledge/compliance/nerc-cip.md
@@ -117,7 +117,7 @@ The largest CIP enforcement actions in recent years have totaled $10M+ for indiv
 - [NERC CIP standards (current version)](https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx)
 - [NERC enforcement actions](https://www.nerc.com/pa/comp/CE/Pages/default.aspx)
 - [E-ISAC (Electricity Information Sharing and Analysis Center)](https://www.eisac.com/)
-- [NERC Project 2023-09 (Risk Management for Third-Party Cloud Services)](https://www.nerc.com/pa/Stand/Pages/Project2023-09.aspx)
+- [NERC Project 2023-09 (Risk Management for Third-Party Cloud Services)](https://www.nerc.com/standards/reliability-standards-under-development/2023-09-risk-management-for-third-party-cloud-services)
 - [FERC NOPR on cloud services](https://www.ferc.gov/news-events/news/ferc-issues-nopr-cloud-computing)
 
 ## See Also

--- a/knowledge/compliance/nis2.md
+++ b/knowledge/compliance/nis2.md
@@ -147,8 +147,8 @@ The penalty regime is aligned with GDPR in terms of magnitude and is designed to
 ## Reference Links
 
 - [Directive (EU) 2022/2555 (NIS2 official text)](https://eur-lex.europa.eu/eli/dir/2022/2555/oj)
-- [ENISA NIS2 guidance](https://www.enisa.europa.eu/topics/nis-directive)
-- [Member state implementation status](https://www.enisa.europa.eu/topics/nis-directive/nis-visual-tool)
+- [ENISA NIS2 guidance](https://www.enisa.europa.eu/topics/state-of-cybersecurity-in-the-eu/cybersecurity-policies/nis-directive-2)
+- [Member state transposition status (European Commission)](https://digital-strategy.ec.europa.eu/en/policies/nis-transposition)
 
 ## See Also
 

--- a/knowledge/compliance/pipeda-lgpd.md
+++ b/knowledge/compliance/pipeda-lgpd.md
@@ -196,7 +196,7 @@ The first significant LGPD enforcement actions occurred in 2022–2023 and have 
 - [PIPEDA (Office of the Privacy Commissioner of Canada)](https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-personal-information-protection-and-electronic-documents-act-pipeda/)
 - [Bill C-27 (Digital Charter Implementation Act)](https://www.parl.ca/legisinfo/en/bill/44-1/c-27)
 - [LGPD official text (Portuguese)](https://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/L13709.htm)
-- [LGPD English translation (IAPP)](https://iapp.org/resources/article/brazilian-data-protection-law-lgpd-english-translation/)
+- [LGPD English translation (IAPP, PDF)](https://iapp.org/media/pdf/resource_center/Brazilian_General_Data_Protection_Law.pdf)
 - [Brazilian National Data Protection Authority (ANPD)](https://www.gov.br/anpd/pt-br)
 
 ## See Also

--- a/knowledge/frameworks/nist-csf-2.0.md
+++ b/knowledge/frameworks/nist-csf-2.0.md
@@ -140,7 +140,7 @@ Practical implementation of Govern:
 ## Reference Links
 
 - [NIST CSF 2.0 main page](https://www.nist.gov/cyberframework)
-- [NIST CSF 2.0 publication (NIST CSWP 29)](https://csrc.nist.gov/pubs/cswp/29/the-nist-cybersecurity-framework-20/final)
+- [NIST CSF 2.0 publication (NIST CSWP 29)](https://csrc.nist.gov/pubs/cswp/29/the-nist-cybersecurity-framework-csf-20/final)
 - [CSF 2.0 reference tool](https://csrc.nist.gov/Projects/Cybersecurity-Framework/Filters)
 - [NIST CSF 2.0 quick start guides](https://www.nist.gov/cyberframework/getting-started)
 - [Community Profiles](https://www.nist.gov/cyberframework/profiles)

--- a/knowledge/frameworks/nist-sp-800-53.md
+++ b/knowledge/frameworks/nist-sp-800-53.md
@@ -114,7 +114,7 @@ The SSP is the source of truth for the control implementation and is the artifac
 - [NIST SP 800-53A — Assessment Procedures](https://csrc.nist.gov/publications/detail/sp/800-53a/rev-5/final)
 - [NIST SP 800-37 — Risk Management Framework](https://csrc.nist.gov/publications/detail/sp/800-37/rev-2/final)
 - [NIST OSCAL — Open Security Controls Assessment Language](https://pages.nist.gov/OSCAL/)
-- [FedRAMP control selections](https://www.fedramp.gov/baselines/)
+- [FedRAMP Rev5 control reference](https://www.fedramp.gov/2026/reference/controls/) — FedRAMP's vendored NIST SP 800-53 Rev5 control catalog, with per-class ruleset references for baseline applicability
 
 ## See Also
 

--- a/knowledge/general/change-management.md
+++ b/knowledge/general/change-management.md
@@ -77,7 +77,7 @@ Organizations subject to compliance frameworks (SOX, PCI-DSS, FedRAMP, HIPAA) fa
 
 - [ITIL 4 Change Enablement](https://www.axelos.com/certifications/itil-service-management)
 - [ServiceNow Change Management](https://docs.servicenow.com/bundle/change-management/)
-- [Jira Service Management Change Management](https://www.atlassian.com/software/jira/service-management/change-management)
+- [Jira Service Management Change Management](https://www.atlassian.com/software/jira/service-management/product-guide/getting-started/change-management)
 - [BMC Helix ITSM](https://www.bmc.com/it-solutions/bmc-helix-itsm.html)
 - [ArgoCD - GitOps](https://argo-cd.readthedocs.io/)
 - [AWS Config Conformance Packs](https://docs.aws.amazon.com/config/latest/developerguide/conformance-packs.html)

--- a/knowledge/general/finops.md
+++ b/knowledge/general/finops.md
@@ -109,7 +109,7 @@ Commitment discounts represent the single largest optimization lever, offering 3
 - [Kubecost](https://www.kubecost.com/)
 - [OpenCost](https://www.opencost.io/)
 - [Infracost](https://www.infracost.io/)
-- [CloudHealth by VMware](https://www.vmware.com/products/aria-cost.html)
+- [VMware Tanzu CloudHealth (formerly CloudHealth by VMware / Aria Cost)](https://www.broadcom.com/products/software/finops/cloudhealth)
 - [Vantage](https://www.vantage.sh/)
 
 ## See Also

--- a/knowledge/general/load-balancing-onprem.md
+++ b/knowledge/general/load-balancing-onprem.md
@@ -104,7 +104,7 @@ On-premises environments lack the managed load balancers available in public clo
 - **HAProxy official docs**: [Configuration Manual](https://docs.haproxy.org/) -- comprehensive reference for all directives including stick tables, ACLs, and health checks
 - **NGINX Load Balancing Guide**: [HTTP Load Balancing](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/) -- upstream configuration, health checks (Plus), and session persistence
 - **F5 BIG-IP Deployment Guides**: [F5 iApp Templates](https://www.f5.com/services/resources/deployment-guides) -- validated configurations for common applications (Exchange, SharePoint, SAP)
-- **keepalived documentation**: [keepalived.org](https://www.keepalived.org/manpage.html) -- VRRP configuration, health check scripts, and notification scripts
+- **keepalived documentation**: [keepalived.org documentation index](https://keepalived.org/documentation/) -- links the `keepalived.conf` man page (the exhaustive keyword reference for VRRP instances, health checkers, and notify scripts) plus the user guide and design papers
 - **Digital Ocean HAProxy HA tutorial**: Practical walkthrough of keepalived + HAProxy active-passive on Linux -- applicable pattern for any on-prem deployment
 - **Red Hat HA Load Balancing**: RHEL documentation covers keepalived + HAProxy integration with SELinux and firewalld considerations
 

--- a/knowledge/general/performance-testing.md
+++ b/knowledge/general/performance-testing.md
@@ -228,7 +228,7 @@ Before full rollout, send a percentage of production traffic to the new version:
 - [Gatling Documentation](https://docs.gatling.io/) — JVM-based load testing with Scala/Java/Kotlin
 - [Google Web Vitals](https://web.dev/vitals/) — Core Web Vitals metrics and thresholds
 - [Google Lighthouse](https://developer.chrome.com/docs/lighthouse/) — Automated auditing for performance, accessibility, and best practices
-- [k6 Operator for Kubernetes](https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/usage/executing-with-k6-operator/) — Running distributed k6 tests in Kubernetes
+- [k6 Operator for Kubernetes](https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/) — Running distributed k6 tests in Kubernetes
 - [Grafana Cloud k6](https://grafana.com/products/cloud/k6/) — Managed cloud load testing service
 - [GoReplay](https://goreplay.org/) — Open-source HTTP traffic replay tool
 - [Istio Traffic Mirroring](https://istio.io/latest/docs/tasks/traffic-management/mirroring/) — Shadow traffic for production testing

--- a/knowledge/general/supply-chain-security.md
+++ b/knowledge/general/supply-chain-security.md
@@ -100,9 +100,9 @@ Beyond compliance, supply chain security directly affects operational resilience
 
 - [SLSA Framework](https://slsa.dev/)
 - [Sigstore](https://www.sigstore.dev/)
-- [cosign](https://docs.sigstore.dev/cosign/overview/)
+- [cosign](https://docs.sigstore.dev/cosign/signing/)
 - [NIST SSDF SP 800-218](https://csrc.nist.gov/publications/detail/sp/800-218/final)
-- [Executive Order 14028](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)
+- [Executive Order 14028](https://www.federalregister.gov/documents/2021/05/17/2021-10460/improving-the-nations-cybersecurity)
 - [CycloneDX SBOM Standard](https://cyclonedx.org/)
 - [SPDX Specification](https://spdx.dev/)
 - [Syft (SBOM Generator)](https://github.com/anchore/syft)

--- a/knowledge/patterns/change-window-alert-suppression.md
+++ b/knowledge/patterns/change-window-alert-suppression.md
@@ -101,7 +101,8 @@ The pattern resolves a tension between **noise reduction** and **not going blind
 - [ServiceNow Event Management -- alert suppression and maintenance](https://docs.servicenow.com/bundle/washingtondc-it-operations-management/page/product/event-management/concept/alert-management.html) -- maintenance-window suppression rules and event correlation that drive the change-linked, auditable suppression layer
 - [Prometheus AlertManager -- inhibition](https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule) -- `inhibit_rules` where a host-down alert inhibits child service alerts; the parent-cascade mechanic at the alerting layer
 - [Prometheus AlertManager -- silences](https://prometheus.io/docs/alerting/latest/configuration/) -- time-bound silences for bounding a blackout to the change window
-- [SolarWinds Orion -- dependency-based alert suppression](https://documentation.solarwinds.com/en/success_center/orionplatform/content/core-managing-dependencies-sw1450.htm) -- suppress child alerts when the parent node is down; maintenance/unmanage scheduling
+- [SolarWinds Platform -- dependency-based alert suppression](https://documentation.solarwinds.com/en/success_center/orionplatform/content/core-managing-dependencies-sw1688.htm) -- network object dependencies mark children Unreachable rather than Down so child alerts do not fire when the parent node is down
+- [SolarWinds Platform -- Maintenance Mode / unmanage scheduling](https://documentation.solarwinds.com/en/success_center/orionplatform/content/core-setting-device-management-states-sw2036.htm) -- suspend polling and alerting for nodes over a scheduled window
 - [OpenStack Nova -- migrate and evacuate](https://docs.openstack.org/nova/latest/admin/migration.html) -- the host-evacuating operations whose alert footprint Tier 1 suppression covers
 
 ## See Also

--- a/knowledge/patterns/lenovo-hybrid-cloud.md
+++ b/knowledge/patterns/lenovo-hybrid-cloud.md
@@ -80,13 +80,13 @@ The **Lenovo-Veeam partnership** is one of the strongest backup-vendor partnersh
 
 ## Reference Links
 
-- [Lenovo TruScale Infrastructure Services](https://www.lenovo.com/us/en/services/truscale/infrastructure-services/) -- consumption-based infrastructure delivery
+- [Lenovo TruScale Infrastructure as a Service datasheet](https://lenovopress.lenovo.com/datasheet/ds0164-lenovo-truscale-infrastructure-as-a-service) -- consumption-based infrastructure delivery
 - [Lenovo ThinkAgile MX Series](https://www.lenovo.com/us/en/p/servers-storage/data-management/integrated-systems/thinkagile-mx-series/wmd00000489) -- Azure Stack HCI on Lenovo hardware
 - [Lenovo XClarity One](https://www.lenovo.com/us/en/data-center/software/management/xclarity-orchestrator/) -- cloud-managed server orchestration
 - [Lenovo ThinkSystem](https://www.lenovo.com/us/en/c/servers-storage/servers/) -- enterprise server portfolio
 - [Azure Arc-enabled servers](https://learn.microsoft.com/en-us/azure/azure-arc/servers/overview) -- Microsoft governance for Lenovo on-prem servers
 - [Azure Stack HCI overview](https://learn.microsoft.com/en-us/azure-stack/hci/) -- Microsoft documentation for the platform that ThinkAgile MX delivers
-- [Veeam-Lenovo partnership](https://www.veeam.com/lenovo) -- canonical backup partnership for Lenovo-anchored deployments
+- [Veeam-Lenovo partnership](https://www.veeam.com/solutions/alliance-partner/lenovo.html) -- canonical backup partnership for Lenovo-anchored deployments
 
 ## See Also
 

--- a/knowledge/patterns/pure-hybrid-cloud.md
+++ b/knowledge/patterns/pure-hybrid-cloud.md
@@ -89,10 +89,10 @@ The **VMware-on-Pure integration** is one of Pure's longest-standing hybrid surf
 
 - [Pure-as-a-Service](https://www.purestorage.com/products/pure-as-a-service.html) -- consumption-based delivery model
 - [Cloud Block Store](https://www.purestorage.com/products/cloud-block-storage.html) -- FlashArray semantics in AWS / Azure
-- [Pure1 management platform](https://www.purestorage.com/products/pure1.html) -- cross-environment storage observability
+- [Pure1 management platform](https://www.everpuredata.com/products/monitoring-fleet-management.html) -- cross-environment storage observability
 - [Portworx Enterprise](https://portworx.com/products/portworx-enterprise/) -- Kubernetes storage and data services across environments
 - [ActiveCluster synchronous replication](https://support.purestorage.com/Solutions/Pure_Storage_ActiveCluster) -- zero-RPO synchronous replication
-- [CloudSnap](https://www.purestorage.com/products/file-and-object-storage/flashblade-data-services.html) -- snapshot-to-cloud offload
+- [CloudSnap](https://support.everpuredata.com/r/cloudsnap/cloudsnap) -- snapshot-to-cloud offload
 - [VMware vVols on FlashArray](https://support.purestorage.com/Solutions/VMware) -- per-VM storage policy and snapshot management
 
 ## See Also

--- a/knowledge/patterns/zero-trust.md
+++ b/knowledge/patterns/zero-trust.md
@@ -102,7 +102,7 @@ The cost of implementing zero trust is significant, involving identity infrastru
 - [SPIRE (SPIFFE Runtime Environment)](https://spiffe.io/docs/latest/spire-about/)
 - [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/)
 - [Zscaler Private Access](https://www.zscaler.com/products/zscaler-private-access)
-- [Google BeyondCorp Enterprise](https://cloud.google.com/beyondcorp-enterprise)
+- [Google BeyondCorp (BeyondCorp Enterprise is now Chrome Enterprise Premium)](https://cloud.google.com/beyondcorp)
 - [AWS Verified Access](https://docs.aws.amazon.com/verified-access/)
 - [Illumio Core](https://www.illumio.com/products/illumio-core)
 - [Open Policy Agent (OPA)](https://www.openpolicyagent.org/)

--- a/knowledge/providers/atlassian/itsm.md
+++ b/knowledge/providers/atlassian/itsm.md
@@ -50,5 +50,5 @@ Opsgenie integration is a critical architectural component for incident manageme
 ## Reference Links
 
 - [Jira Service Management Documentation](https://support.atlassian.com/jira-service-management-cloud/) -- request types, SLAs, automation rules, and service desk configuration
-- [Jira Service Management Assets (CMDB)](https://support.atlassian.com/jira-service-management-cloud/docs/manage-assets-with-jira-service-management/) -- asset schemas, object types, and CMDB configuration
+- [Jira Service Management Assets (CMDB)](https://support.atlassian.com/jira-service-management-cloud/docs/manage-your-assets-and-configuration-items-with-assets/) -- asset schemas, object types, and CMDB configuration
 - [Opsgenie Documentation](https://support.atlassian.com/opsgenie/) -- incident alerting, on-call schedules, escalation policies, and integration with JSM

--- a/knowledge/providers/atlassian/jsm-operations.md
+++ b/knowledge/providers/atlassian/jsm-operations.md
@@ -47,9 +47,9 @@ Linked-issue discipline underpins proper root-cause analysis. An incident withou
 
 ## Reference Links
 
-- [JSM SLAs](https://support.atlassian.com/jira-service-management-cloud/docs/create-and-edit-slas/) -- configuring start, pause, stop, and goal conditions
-- [SLA smart values](https://support.atlassian.com/cloud-automation/docs/jira-smart-values-service-level-agreements/) -- using SLA fields in automation and JQL
-- [JSM queues](https://support.atlassian.com/jira-service-management-cloud/docs/manage-queues-in-your-service-project/) -- creating and organizing agent queues
-- [Jira automation rules](https://support.atlassian.com/cloud-automation/docs/jira-automation-components/) -- triggers, conditions, actions, and branch rules
+- [JSM SLAs](https://support.atlassian.com/jira-service-management-cloud/docs/create-an-sla/) -- configuring start, pause, stop, and goal conditions
+- [SLA smart values](https://support.atlassian.com/jira/kb/how-to-find-smart-value-of-sla-component-of-jsm-issues/) -- locating SLA smart values (`ongoingCycle`, `completedCycle`) for use in automation rules
+- [JSM queues](https://support.atlassian.com/jira-service-management-cloud/docs/what-are-queues/) -- creating and organizing agent queues
+- [Jira automation rules](https://support.atlassian.com/cloud-automation/docs/what-are-automation-rules/) -- triggers, conditions, actions, and branches
 - [Automation rule execution limits](https://support.atlassian.com/cloud-automation/docs/automation-service-limits/) -- per-plan monthly execution budgets
 - [Linking issues](https://support.atlassian.com/jira-software-cloud/docs/link-issues/) -- issue link types including `is caused by`, `relates to`, `implements`

--- a/knowledge/providers/aws/snow-family.md
+++ b/knowledge/providers/aws/snow-family.md
@@ -82,7 +82,7 @@ A cluster of 5 Snowball Edge devices deployed to an Arctic or Antarctic research
 ## Reference Links
 
 - [AWS Snow Family Documentation](https://docs.aws.amazon.com/snowball/latest/developer-guide/) -- Snowcone and Snowball Edge ordering, configuration, data transfer, and edge compute
-- [AWS Snow Family Pricing](https://aws.amazon.com/snow/pricing/) -- device fees, shipping, data transfer, and commitment terms
+- [AWS Snowball Pricing](https://aws.amazon.com/snowball/pricing/) -- device fees, shipping, data transfer, and commitment terms
 
 ## See Also
 

--- a/knowledge/providers/azure/bicep.md
+++ b/knowledge/providers/azure/bicep.md
@@ -354,7 +354,7 @@ Environments (each a parameter file):
 
 - [Bicep documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/) -- language reference, modules, deployment scopes, and best practices
 - [Bicep Playground](https://aka.ms/bicepdemo) -- interactive browser-based Bicep editor with ARM template decompilation
-- [Azure Verified Modules](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/azure-verified-modules) -- curated, tested Bicep modules for common Azure resource patterns
+- [Azure Verified Modules](https://learn.microsoft.com/en-us/community/content/azure-verified-modules) -- curated, tested Bicep modules for common Azure resource patterns
 - [Deployment stacks documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-stacks) -- resource lifecycle management and deny assignments
 
 ## See Also

--- a/knowledge/providers/azure/commercial-programs.md
+++ b/knowledge/providers/azure/commercial-programs.md
@@ -94,7 +94,7 @@ Azure commercial programs directly influence architecture decisions in ways that
 - [Azure Hybrid Benefit for Windows Server](https://learn.microsoft.com/en-us/windows-server/get-started/azure-hybrid-benefit) -- License portability and ESU benefits
 - [Azure Hybrid Benefit for SQL Server](https://learn.microsoft.com/en-us/azure/azure-sql/azure-hybrid-benefit?view=azuresql) -- SQL license portability to Azure SQL services
 - [Microsoft partner incentives guide](https://www.aicloudpartners.com/guides/microsoft-partner-incentives.html) -- FY26 partner incentive programs and co-sell overview
-- [EA pricing tier elimination](https://redresscompliance.com/microsoft-ea-pricing-changes-2025-all-customers-move-to-level-a-pricing/) -- Analysis of November 2025 EA pricing changes
+- [EA pricing tier elimination](https://www.microsoft.com/en-us/licensing/news/online-services-pricing-consistency-update) -- Microsoft's Online Services pricing consistency update: Levels B/C/D retired, all customers to Level A from November 2025
 - `providers/azure/compute.md` -- Azure VM SKU selection and compute architecture
 - `providers/vmware/licensing.md` -- VMware/Broadcom licensing including BYOL to Azure VMware Solution
 - `providers/vmware/avs-azure.md` -- Azure VMware Solution architecture and MACC implications

--- a/knowledge/providers/azure/identity.md
+++ b/knowledge/providers/azure/identity.md
@@ -36,7 +36,7 @@ Microsoft Entra ID is the identity control plane for all Azure resources, Micros
 
 ## Reference Architectures
 
-- [Azure Architecture Center: Identity architecture design](https://learn.microsoft.com/en-us/entra/fundamentals/identity-start-here) -- decision tree for identity integration patterns including hybrid, cloud-only, and B2C
+- [Azure Architecture Center: Get started with identity architecture design](https://learn.microsoft.com/en-us/azure/architecture/identity/identity-get-started) -- technology-choice guides and reference architectures for identity integration patterns including hybrid, cloud-only, and external (customer/partner) identities
 - [Microsoft Entra ID deployment guide](https://learn.microsoft.com/en-us/entra/fundamentals/concept-secure-remote-workers) -- phased deployment of conditional access, MFA, and identity protection
 - [Azure Landing Zone: Identity and access management](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/identity-access) -- Cloud Adoption Framework guidance for enterprise identity design
 - [Azure Well-Architected Framework: Identity and access management](https://learn.microsoft.com/en-us/azure/well-architected/security/identity-access) -- security pillar guidance for authentication, authorization, and identity governance

--- a/knowledge/providers/cassandra/database.md
+++ b/knowledge/providers/cassandra/database.md
@@ -81,6 +81,6 @@ Operational disciplines that are optional in other databases are mandatory in Ca
 
 - [Apache Cassandra Documentation](https://cassandra.apache.org/doc/latest/) -- architecture, CQL, configuration, and operational procedures
 - [DataStax Cassandra Documentation](https://docs.datastax.com/) -- DataStax Enterprise features, Astra DB, drivers, and best practices
-- [Cassandra Data Modeling Guide](https://cassandra.apache.org/doc/latest/cassandra/data_modeling/index.html) -- query-driven data modeling, partition design, and denormalization patterns
+- [Cassandra Data Modeling Guide](https://cassandra.apache.org/doc/latest/cassandra/developing/data-modeling/index.html) -- query-driven data modeling, partition design, and denormalization patterns
 - [K8ssandra Documentation](https://docs.k8ssandra.io/) -- Kubernetes operator for Cassandra with Reaper, Medusa, and Stargate
 - [The Last Pickle - Cassandra Blog](https://thelastpickle.com/blog/) -- advanced Cassandra operations, repair strategies, and performance tuning

--- a/knowledge/providers/checkpoint/firewall.md
+++ b/knowledge/providers/checkpoint/firewall.md
@@ -90,4 +90,7 @@ Policy layers (introduced in R80+) provide the structural tools to decompose mon
 
 - [Check Point Security Management](https://sc1.checkpoint.com/documents/latest/APIs/) -- SmartConsole, policy layers, and Security Management Server administration
 - [Check Point CloudGuard](https://sc1.checkpoint.com/documents/CloudGuard_Dome9/Default.htm) -- cloud-native security, posture management, and workload protection
-- [Check Point R81.x Administration Guide](https://sc1.checkpoint.com/documents/R81.20/WebAdminGuide/Default.htm) -- gateway configuration, VSX, Maestro, and ClusterXL HA
+- [Check Point R81.20 Quantum Security Gateway Administration Guide](https://sc1.checkpoint.com/documents/R81.20/WebAdminGuides/EN/CP_R81.20_SecurityGateway_Guide/Default.htm) -- gateway configuration, SecureXL/CoreXL acceleration, and inspection settings
+- [Check Point R81.20 ClusterXL Administration Guide](https://sc1.checkpoint.com/documents/R81.20/WebAdminGuides/EN/CP_R81.20_ClusterXL_AdminGuide/Default.htm) -- ClusterXL HA and Load Sharing, sync network, and cluster failover
+- [Check Point R81.20 VSX Administration Guide](https://sc1.checkpoint.com/documents/R81.20/WebAdminGuides/EN/CP_R81.20_VSX_AdminGuide/Default.htm) -- virtual systems, virtual routers/switches, and VSLS
+- [Check Point R81.20 Quantum Maestro Administration Guide](https://sc1.checkpoint.com/documents/R81.20/WebAdminGuides/EN/CP_R81.20_Maestro_AdminGuide/Default.htm) -- Security Groups, orchestrator configuration, and scalable platform sizing

--- a/knowledge/providers/chef/configuration.md
+++ b/knowledge/providers/chef/configuration.md
@@ -43,6 +43,6 @@ Progress Software acquired Chef in 2020, which has raised questions about long-t
 
 ## Reference Links
 
-- [Chef Infra Documentation](https://docs.chef.io/chef_overview/) -- server/client architecture, cookbooks, recipes, and resource types
+- [Chef Infra Documentation](https://docs.chef.io/platform_overview/) -- server/client architecture, cookbooks, recipes, and resource types
 - [Chef InSpec Documentation](https://docs.chef.io/inspec/) -- compliance-as-code framework for auditing and testing infrastructure
 - [Chef Supermarket](https://supermarket.chef.io/) -- community cookbook repository for reusable infrastructure automation

--- a/knowledge/providers/cisco/meraki.md
+++ b/knowledge/providers/cisco/meraki.md
@@ -35,7 +35,7 @@ Meraki's cloud-managed model fundamentally changes network operations -- the sim
 ## Reference Links
 
 - [Meraki documentation](https://documentation.meraki.com/) -- Dashboard configuration, MX/MS/MR deployment guides, and API reference
-- [Meraki MX sizing guide](https://documentation.meraki.com/MX/MX_Overview_and_Specifications) -- MX appliance throughput ratings with and without advanced security features
+- [Meraki MX sizing guide](https://documentation.meraki.com/SASE_and_SD-WAN/MX/Design_and_Configure/Architectures_and_Best_Practices/MX_Sizing_Guide_%26_Principles) -- MX appliance throughput ratings with and without advanced security features
 - [Meraki SD-WAN and AutoVPN](https://documentation.meraki.com/MX/Site-to-site_VPN/Meraki_Auto_VPN_-_Configuration_and_Troubleshooting) -- AutoVPN configuration, hub-and-spoke design, and non-Meraki VPN peering
 - [Meraki API documentation](https://developer.cisco.com/meraki/api/) -- REST API reference for dashboard automation, webhook configuration, and integration
 - [Meraki licensing overview](https://documentation.meraki.com/General_Administration/Licensing/Meraki_Licensing_FAQs) -- Per-device licensing model, tier comparison, and renewal management

--- a/knowledge/providers/citrix/adc.md
+++ b/knowledge/providers/citrix/adc.md
@@ -42,5 +42,5 @@ Migration scenarios are common as organizations move from MPX hardware to VPX vi
 ## Reference Links
 
 - [Citrix ADC Documentation](https://docs.citrix.com/en-us/citrix-adc.html) -- virtual servers, content switching, SSL offloading, GSLB, and WAF configuration
-- [Citrix ADC Deployment Guides](https://docs.citrix.com/en-us/tech-zone/build/deployment-guides.html) -- reference architectures for common deployment scenarios
+- [NetScaler ADC (Citrix ADC) Deployment Solutions](https://docs.netscaler.com/en-us/citrix-adc/current-release/solutions.html) -- reference architectures for common deployment scenarios
 - [Citrix ADC Pooled Capacity](https://docs.citrix.com/en-us/citrix-application-delivery-management-software/current-release/license-server/adc-pooled-capacity.html) -- flexible licensing across VPX, SDX, and CPX form factors

--- a/knowledge/providers/commvault/backup.md
+++ b/knowledge/providers/commvault/backup.md
@@ -73,6 +73,6 @@ The architecture decisions above (CommServe sizing, storage policies, dedup) det
 
 ## Reference Links
 
-- [Commvault Documentation](https://documentation.commvault.com/2024e/essential/overview.html) -- CommServe, MediaAgent, storage policies, and IntelliSnap configuration
-- [Commvault Architecture Guide](https://documentation.commvault.com/2024e/essential/architecture_overview.html) -- deployment topologies, component sizing, and network requirements
-- [Metallic SaaS Backup](https://documentation.commvault.com/metallic/) -- cloud-managed backup service documentation
+- [Commvault Documentation (LTS 11.44)](https://documentation.commvault.com/11.44/software/index.html) -- CommServe, MediaAgent, storage policies, and IntelliSnap configuration
+- [CommCell Logical Architecture](https://documentation.commvault.com/11.44/commcell-console/commcell_logical_architecture.html) -- CommServe, MediaAgent, and client components; agents, backup sets, subclients, and storage policies
+- [Commvault SaaS Backup](https://documentation.commvault.com/saas/) -- cloud-managed backup service documentation (formerly branded Metallic)

--- a/knowledge/providers/cyberark/pam.md
+++ b/knowledge/providers/cyberark/pam.md
@@ -61,5 +61,5 @@ Credential rotation failures are the most common operational issue in CyberArk d
 - [CyberArk Privilege Cloud Documentation](https://docs.cyberark.com/privilege-cloud-shared-services/latest/en/Content/Resources/_TopNav/cc_Home.htm) -- SaaS PAM deployment, connector setup, and cloud administration
 - [CyberArk Conjur Documentation](https://docs.cyberark.com/conjur-enterprise/latest/en/Content/Resources/_TopNav/cc_Home.htm) -- Conjur secrets management for DevOps, Kubernetes, and CI/CD integration
 - [CyberArk Secrets Manager Documentation](https://docs.cyberark.com/credential-providers/latest/en/Content/Resources/_TopNav/cc_Home.htm) -- Credential Provider and Central Credential Provider for application credential retrieval
-- [CyberArk Security Hardening Guide](https://docs.cyberark.com/pam-self-hosted/latest/en/Content/PAS%20SysReq/Recommended-Server-Configurations.htm) -- Vault server hardening, network requirements, and infrastructure sizing
+- [CyberArk Recommended Server Specifications](https://docs.cyberark.com/pam-self-hosted/latest/en/content/pas%20sysreq/recommended%20server%20specifications.htm) -- Vault, PVWA, CPM, and PSM server sizing and infrastructure requirements
 - [CyberArk Marketplace](https://cyberark-customers.force.com/mplace/s/#/) -- community-contributed platforms, integrations, and custom connection components

--- a/knowledge/providers/dell/apex.md
+++ b/knowledge/providers/dell/apex.md
@@ -40,8 +40,7 @@ APEX represents Dell's shift to as-a-service consumption, competing with HPE Gre
 
 - [Dell APEX Overview](https://www.dell.com/en-us/dt/apex/index.htm) -- APEX portfolio overview and service descriptions
 - [APEX Cloud Platform Documentation](https://infohub.delltechnologies.com/en-us/t/apex-cloud-platform/) -- Dell InfoHub with deployment and administration guides
-- [APEX Console](https://www.dell.com/en-us/dt/apex/apex-console.htm) -- unified management console for all APEX services
-- [APEX Navigator for Multicloud](https://www.dell.com/en-us/dt/apex/apex-navigator.htm) -- multicloud Kubernetes management with APEX
+- [APEX Navigator overview](https://infohub.delltechnologies.com/en-us/l/dell-apex-navigator/overview-6503/) -- multicloud storage and Kubernetes management delivered through the APEX Console
 - [Dell APEX Pricing and Packaging](https://www.dell.com/en-us/dt/apex/index.htm) -- subscription options and service tiers
 - [APEX Cloud Platform for VCF Reference Architecture](https://infohub.delltechnologies.com/en-us/t/apex-cloud-platform/) -- validated designs for APEX Cloud Platform deployments
 

--- a/knowledge/providers/dell/poweredge.md
+++ b/knowledge/providers/dell/poweredge.md
@@ -47,7 +47,7 @@ PowerEdge servers are the most widely deployed x86 server platform globally. Con
 - [OpenManage Enterprise User Guide](https://www.dell.com/support/kbdoc/en-us/000176472/dell-openmanage-enterprise-user-s-guide) -- centralized server management platform documentation
 - [Dell PowerEdge RAID Controller (PERC) Guide](https://www.dell.com/support/kbdoc/en-us/000178016/dell-poweredge-understanding-raid-levels-and-perc-controllers) -- RAID configuration best practices
 - [Dell OpenManage Ansible Modules](https://github.com/dell/dellemc-openmanage-ansible-modules) -- infrastructure-as-code automation for PowerEdge servers
-- [Dell Support Matrix for VMware](https://www.dell.com/support/kbdoc/en-us/000203498/support-matrix-for-dell-emc-vmware-solutions) -- validated firmware and driver combinations for VMware deployments
+- [Dell Firmware Catalog for Dell-Customized VMware ESXi Images](https://www.dell.com/support/kbdoc/en-us/000126599/firmware-catalog-for-dell-customized-vmware-esxi-images) -- validated firmware and driver combinations for VMware ESXi deployments
 
 ## See Also
 

--- a/knowledge/providers/dell/powerscale.md
+++ b/knowledge/providers/dell/powerscale.md
@@ -43,9 +43,9 @@ PowerScale is the industry-leading scale-out NAS platform, handling the largest 
 
 - [Dell PowerScale Documentation](https://www.dell.com/support/home/en-us/product-support/product/isilon/docs) -- official OneFS administration and configuration guides
 - [OneFS Best Practices Guide](https://infohub.delltechnologies.com/en-us/t/powerscale-isilon/) -- Dell InfoHub with white papers and best practices for PowerScale
-- [PowerScale SmartConnect Guide](https://www.dell.com/support/kbdoc/en-us/000021938/isilon-smartconnect-overview) -- DNS-based load balancing configuration and troubleshooting
+- [PowerScale Network Design Considerations (SmartConnect)](https://infohub.delltechnologies.com/en-us/l/dell-powerscale-network-design-considerations/) -- SmartConnect DNS-based load balancing, allocation methods, and network design
 - [PowerScale SyncIQ Replication Guide](https://infohub.delltechnologies.com/en-us/t/powerscale-isilon/) -- asynchronous replication configuration for DR
-- [PowerScale Security Configuration Guide](https://www.dell.com/support/kbdoc/en-us/000021933/isilon-authentication-and-access-control) -- authentication, access zones, and RBAC configuration
+- [PowerScale OneFS Authentication, Identity Management, and Authorization](https://infohub.delltechnologies.com/en-us/l/powerscale-onefs-authentication-identity-management-and-authorization/) -- authentication providers, access zones, and RBAC configuration
 - [PowerScale for AI/ML Data Pipelines](https://infohub.delltechnologies.com/en-us/t/powerscale-isilon/) -- reference architectures for NVIDIA GPU clusters with PowerScale storage
 
 ## See Also

--- a/knowledge/providers/dell/powerstore.md
+++ b/knowledge/providers/dell/powerstore.md
@@ -42,7 +42,7 @@ PowerStore is Dell's modern midrange storage platform, replacing VNX, Unity, and
 
 - [Dell PowerStore Documentation](https://www.dell.com/support/home/en-us/product-support/product/powerstore/docs) -- official product documentation and guides
 - [PowerStore Best Practices Guide](https://infohub.delltechnologies.com/en-us/t/powerstore/) -- Dell InfoHub with best practices and white papers
-- [PowerStore Host Configuration Guide](https://www.dell.com/support/kbdoc/en-us/000199067/dell-powerstore-host-configuration-guide) -- multipathing and host connectivity settings for ESXi, Linux, and Windows
+- [PowerStore host configuration best practices](https://infohub.delltechnologies.com/en-us/l/dell-powerstore-best-practices-guide/host-configuration-53/) -- multipathing and host connectivity settings for ESXi, Linux, and Windows
 - [PowerStore Networking Guide](https://infohub.delltechnologies.com/en-us/t/powerstore/) -- network configuration best practices for iSCSI and NVMe-oF
 - [Dell PowerStore Ansible Collection](https://github.com/dell/ansible-powerstore) -- infrastructure-as-code automation for PowerStore provisioning
 - [Dell CloudIQ](https://www.dell.com/en-us/dt/storage/cloudiq.htm) -- proactive monitoring and analytics for Dell storage

--- a/knowledge/providers/dynatrace/observability.md
+++ b/knowledge/providers/dynatrace/observability.md
@@ -61,5 +61,5 @@ The consumption-based pricing (DDU model) is simpler than per-host-per-capabilit
 - [Dynatrace Grail](https://docs.dynatrace.com/docs/platform/grail) -- Grail data lakehouse architecture, retention policies, and DQL querying
 - [Davis AI](https://docs.dynatrace.com/docs/platform/davis-ai) -- Davis AI engine, problem detection, root cause analysis, and alerting configuration
 - [Dynatrace Pricing](https://www.dynatrace.com/pricing/) -- DDU consumption model, platform subscription tiers, and committed use discounts
-- [Dynatrace OpenTelemetry Integration](https://docs.dynatrace.com/docs/extend/opentelemetry) -- OTLP ingestion, OpenTelemetry Collector configuration, and hybrid instrumentation
+- [Dynatrace OpenTelemetry Integration](https://docs.dynatrace.com/docs/ingest-from/opentelemetry) -- OTLP ingestion, OpenTelemetry Collector configuration, and hybrid instrumentation
 - [Dynatrace Hub](https://www.dynatrace.com/hub/) -- Extensions, integrations, and technology support catalog

--- a/knowledge/providers/gcp/devops.md
+++ b/knowledge/providers/gcp/devops.md
@@ -63,7 +63,7 @@ Cloud Build private worker pool in shared VPC (10.0.0.0/24 subnet). Build steps 
 - [Cloud Deploy documentation](https://cloud.google.com/deploy/docs) -- delivery pipelines, deployment strategies, canary verification, and approvals
 - [Artifact Registry documentation](https://cloud.google.com/artifact-registry/docs) -- container images, language packages, remote repositories, and vulnerability scanning
 - [Binary Authorization documentation](https://cloud.google.com/binary-authorization/docs) -- attestation policies, attestors, and supply chain security enforcement
-- [Software Delivery Shield overview](https://cloud.google.com/software-delivery-shield/docs) -- end-to-end supply chain security posture management
+- [Software Delivery Shield overview](https://cloud.google.com/software-supply-chain-security/docs/sds/overview) -- end-to-end supply chain security posture management
 
 ## See Also
 

--- a/knowledge/providers/google/workspace.md
+++ b/knowledge/providers/google/workspace.md
@@ -61,8 +61,8 @@ Google Workspace security relies heavily on correct Admin Console configuration:
 - [Google Workspace Admin Help](https://support.google.com/a) -- Admin Console configuration, user management, and domain setup
 - [Google Workspace Security Best Practices](https://support.google.com/a/answer/7587183) -- security checklist for administrators
 - [Google Cloud Directory Sync](https://support.google.com/a/answer/106368) -- GCDS setup for Active Directory synchronization
-- [Google Workspace Migrate](https://support.google.com/workspacemigrate/answer/10839818) -- migration tool for Exchange, M365, and other platforms
-- [GWMME Administration Guide](https://support.google.com/workspacemigrate/answer/6055847) -- Google Workspace Migration for Microsoft Exchange
+- [Google Workspace Migrate](https://support.google.com/workspacemigrate/answer/9222862) -- migration tool for SharePoint/OneDrive, file shares, Box, and Exchange sources (Exchange Online support ends October 2026)
+- [About GWMME](https://support.google.com/a/answer/180898) -- Google Workspace Migration for Microsoft Exchange
 - [Google Vault Documentation](https://support.google.com/vault) -- retention rules, legal holds, eDiscovery, and audit
 - [Context-Aware Access](https://support.google.com/a/answer/9275380) -- device and context-based access policies
 - [Google Workspace Updates Blog](https://workspaceupdates.googleblog.com/) -- feature announcements and rollout schedules

--- a/knowledge/providers/hashicorp/boundary.md
+++ b/knowledge/providers/hashicorp/boundary.md
@@ -120,7 +120,7 @@ Global scope contains org-level auth methods (OIDC). Orgs map to business units.
 
 - [Boundary Documentation](https://developer.hashicorp.com/boundary/docs) -- architecture, deployment models, targets, credential injection, and session recording
 - [Boundary Tutorials](https://developer.hashicorp.com/boundary/tutorials) -- hands-on guides for HCP Boundary, self-managed deployment, and Vault integration
-- [Boundary Reference Architecture](https://developer.hashicorp.com/boundary/docs/install-boundary/reference/reference-architecture) -- production deployment patterns for self-managed Boundary
+- [Boundary Recommended Architecture](https://developer.hashicorp.com/boundary/docs/architecture/recommended-architecture) -- production deployment patterns for self-managed Boundary
 
 ## See Also
 

--- a/knowledge/providers/hashicorp/certifications.md
+++ b/knowledge/providers/hashicorp/certifications.md
@@ -59,9 +59,8 @@ Terraform is the dominant IaC tool across cloud providers, and Terraform Associa
 
 ## Reference Links
 
-- [HashiCorp Certifications](https://developer.hashicorp.com/certifications) -- Terraform Associate, Vault Associate/Professional, and Consul Associate exam details
+- [HashiCorp Certifications](https://developer.hashicorp.com/certifications) -- Terraform Associate, Vault Associate/Professional, and Consul Associate exam details, plus exam format, two-year validity period, and recertification rules
 - [HashiCorp Developer Tutorials](https://developer.hashicorp.com/tutorials) -- free hands-on training aligned to certification topics
-- [HashiCorp Certification FAQ](https://developer.hashicorp.com/certifications/faq) -- exam format, validity period, renewal process, and retake policies
 
 ## See Also
 

--- a/knowledge/providers/ibm/power-management.md
+++ b/knowledge/providers/ibm/power-management.md
@@ -69,12 +69,12 @@ LPM is the operational capability that separates planned maintenance from planne
 - [Virtual HMC appliance (vHMC) Overview](https://www.ibm.com/support/pages/virtual-hmc-appliance-vhmc-overview) -- vHMC on PowerVM vs vHMC on x86, supported hypervisors, PTF stream separation
 - [Configuring Redundant HMCs](https://www.ibm.com/support/pages/configuring-redundant-hmcs) -- dual-HMC topology, FSP wiring, DHCP IP-range partitioning
 - [Concurrent vs Disruptive Firmware Update and Upgrade on Power Systems](https://www.ibm.com/support/pages/concurrent-vs-disruptive-firmware-update-and-upgrade-power-systems) -- classification rules including Power10 SBE and EMX0/EMXH constraints
-- [Power9, Power10 and Power11 System FW Release Planned Schedule (2025-2026)](https://www.ibm.com/support/pages/power9-power10-and-power11-system-fw-release-planned-schedule-2025-2026-updated-november-2025) -- IBM-published firmware roadmap
+- [Power9, Power10 and Power11 System FW Release Planned Schedule (2025-2027)](https://www.ibm.com/support/pages/power9-power10-and-power11-system-fw-release-planned-schedule-2025-2027-updated-may-2026) -- IBM-published firmware roadmap
 - [IBM Power Virtualization Best Practices Guide v5.0 (October 2025)](https://www.ibm.com/downloads/documents/us-en/107a02e95b48f634) -- LPAR sizing, VIOS, LPM, and management-plane best practices
 - [IBM PowerVC product page](https://www.ibm.com/products/powervc) -- Standard Edition vs Private Cloud Edition positioning
 - [IBM PowerVC for Private Cloud 2.3 documentation](https://www.ibm.com/docs/en/powervc-cloud/2.3.1?topic=introduction) -- current PowerVC documentation, OpenStack API surface, image catalog, placement policies
 - [PowerVC Lifecycle Information](https://www.ibm.com/support/pages/powervc-lifecycle-information) -- PowerVC version support windows
-- [Difference between PowerVC Standard and PowerVC for Private Cloud](https://www.ibm.com/support/pages/what-difference-between-powervc-standard-and-powervc-private-cloud) -- self-service portal, approval workflows, metering
+- [Difference between PowerVC Standard and PowerVC for Private Cloud](https://www.ibm.com/support/pages/node/6549886) -- self-service portal, approval workflows, metering
 - [Live Partition Mobility (IBM Support)](https://www.ibm.com/support/pages/live-partition-mobility) -- LPM prerequisites, mover service partitions, validation workflow
 - [Best Practices for Live Partition Mobility (LPM) Networking](https://www.ibm.com/support/pages/best-practices-live-partition-mobility-lpm-networking) -- MSP bandwidth, management-network latency
 - [Migration combinations of processor compatibility modes](https://www.ibm.com/docs/en/power10/9080-HEX?topic=modes-combinations-active-partition-mobility) -- supported source/target processor-compatibility-mode pairs across Power generations

--- a/knowledge/providers/ibm/power-onprem.md
+++ b/knowledge/providers/ibm/power-onprem.md
@@ -73,7 +73,7 @@ Patch and OS support discipline is the fourth area where Power estates routinely
 - [IBM License Metric Tool (ILMT) product page](https://www.ibm.com/products/ibm-license-metric-tool) -- agent deployment, weekly snapshot, 90-day retention, sub-capacity audit reporting
 - [Precisely Assure MIMIX](https://www.precisely.com/product/precisely-assure/assure-mimix) -- IBM i journal-based replication, object-level HA
 - [IBM Power Virtualization Best Practices Guide](https://www.ibm.com/support/pages/ibm-power-virtualization-best-practices-guide) -- LPAR sizing, VIOS configuration, performance tuning
-- [IBM HMC documentation](https://www.ibm.com/docs/en/power-hmc) -- Hardware Management Console operations, redundancy, firmware compatibility
+- [IBM HMC documentation](https://www.ibm.com/support/pages/hardware-management-console-related-technical-information) -- Hardware Management Console operations, redundancy, firmware compatibility
 - [IBM PowerVC documentation](https://www.ibm.com/docs/en/powervc) -- OpenStack-style provisioning for on-prem Power
 - [NIM (Network Installation Manager) overview](https://www.ibm.com/docs/en/aix) -- AIX network-based mksysb restore
 - [BRMS for IBM i](https://www.ibm.com/products/backup-recovery-and-media-services-for-i) -- backup scheduling, media management, restore orchestration

--- a/knowledge/providers/jenkins/ci-cd.md
+++ b/knowledge/providers/jenkins/ci-cd.md
@@ -50,7 +50,7 @@ Plugin management is an ongoing operational challenge. Plugins frequently have i
 - [Jenkins Plugin Index](https://plugins.jenkins.io/)
 - [Jenkins Security Advisories](https://www.jenkins.io/security/advisories/)
 - [Jenkins LTS Changelog](https://www.jenkins.io/changelog-stable/)
-- [Jenkins X Documentation](https://jenkins-x.io/docs/)
+- [Jenkins X Documentation (project renamed JayeX)](https://jayex.io/v3/)
 - [Managing Jenkins Plugins](https://www.jenkins.io/doc/book/managing/plugins/)
 
 ## See Also

--- a/knowledge/providers/kyndryl/bridge.md
+++ b/knowledge/providers/kyndryl/bridge.md
@@ -53,7 +53,7 @@ Agentic automation scope matters because the default -- ~200M automations/month 
 
 - [Kyndryl Bridge platform overview](https://www.kyndryl.com/us/en/services/platform) -- Integrate / Observe / Orchestrate model, service catalog, AI insight volumes, customer outcomes
 - [Kyndryl Bridge service catalog](https://www.kyndryl.com/bridge) -- the 190+ services available through Bridge
-- [Kyndryl Bridge documentation](https://docs.kyndryl.com/us/en/getting-started/introduction-to-kyndryl-bridge) -- getting started, onboarding, technical architecture
+- [Kyndryl Bridge documentation](https://docs.kyndryl.com/introduction-to-kyndryl-bridge) -- getting started, onboarding, technical architecture
 - [Kyndryl Agentic Service Management](https://www.kyndryl.com/in/en/about-us/news/2026/04/new-agentic-service-management) -- 2026 maturity model and blueprint for agentic transformation
 - [Kyndryl Intelligent Recovery Service](https://www.kyndryl.com/us/en/about-us/news/2026/02/new-intelligent-recovery-services) -- KIRS integrated with Bridge for coordinated recovery
 - [Kyndryl Bridge launch announcement (2022)](https://investors.kyndryl.com/news-releases/news-release-details/kyndryl-introduces-new-platform-kyndryl-bridge-orchestrate-it) -- original positioning and platform goals

--- a/knowledge/providers/mongodb/database.md
+++ b/knowledge/providers/mongodb/database.md
@@ -79,7 +79,7 @@ Connection management is another area where MongoDB deployments fail at scale. U
 
 ## Reference Links
 
-- [MongoDB Architecture Guide](https://www.mongodb.com/docs/manual/core/) -- document model, replication, sharding, and storage engine internals
+- [MongoDB Server Manual](https://www.mongodb.com/docs/manual/) -- document model, replication, sharding, and storage engine internals
 - [MongoDB Atlas Documentation](https://www.mongodb.com/docs/atlas/) -- managed service configuration, Atlas Search, Atlas Vector Search, and serverless instances
 - [MongoDB Schema Design Best Practices](https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/) -- embedding vs referencing patterns and common anti-patterns
 - [MongoDB Sharding Documentation](https://www.mongodb.com/docs/manual/sharding/) -- shard key selection, chunk migration, and balancer configuration

--- a/knowledge/providers/morpheus/cloud-management.md
+++ b/knowledge/providers/morpheus/cloud-management.md
@@ -42,7 +42,7 @@ A cloud management platform sits at the control plane of the entire infrastructu
 ## Reference Links
 
 - [Morpheus Documentation](https://docs.morpheusdata.com/)
-- [Morpheus Supported Integrations](https://morpheusdata.com/integrations/)
+- [Morpheus Codeless Integrations](https://morpheusdata.com/hybrid-cloud-management/codeless-integrations/)
 
 ## See Also
 

--- a/knowledge/providers/netapp/cloud-volumes.md
+++ b/knowledge/providers/netapp/cloud-volumes.md
@@ -56,7 +56,7 @@ Network placement constraints are stricter than they appear in the marketing mat
 - [BlueXP Documentation](https://docs.netapp.com/us-en/bluexp-family/) -- unified management plane for hybrid and multi-cloud NetApp deployments
 - [NetApp Hybrid Cloud Reference Architectures](https://www.netapp.com/cloud-services/) -- patterns for SnapMirror replication, cloud bursting, and hybrid disaster recovery
 - [Azure NetApp Files Performance Benchmarks](https://learn.microsoft.com/en-us/azure/azure-netapp-files/performance-benchmarks-linux) -- Linux NFS and Windows SMB performance characteristics by service level
-- [FSx for ONTAP with VMware Cloud on AWS](https://aws.amazon.com/blogs/storage/configuring-amazon-fsx-for-netapp-ontap-as-external-storage-for-vmware-cloud-on-aws/) -- supplemental datastore configuration and use cases
+- [FSx for ONTAP with VMware Cloud on AWS](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/vmware-cloud-ontap.html) -- supplemental NFS datastore configuration and requirements
 
 ## See Also
 

--- a/knowledge/providers/okta/identity.md
+++ b/knowledge/providers/okta/identity.md
@@ -57,8 +57,8 @@ Rate limiting is a frequently overlooked operational concern. Okta enforces stri
 
 - [Okta Product Documentation](https://help.okta.com/en-us/content/index.htm) -- official Okta admin and developer documentation
 - [Okta Integration Network](https://www.okta.com/integrations/) -- catalog of pre-built application integrations
-- [Okta Identity Governance](https://help.okta.com/en-us/content/topics/identity-governance/oig-main.htm) -- access certification, entitlement management, and governance workflows
+- [Okta Identity Governance](https://help.okta.com/en-us/content/topics/identity-governance/iga-overview.htm) -- access certification, entitlement management, and governance workflows
 - [Okta Workflows](https://help.okta.com/wf/en-us/content/topics/workflows/workflows-main.htm) -- no-code identity orchestration and automation
 - [Okta Rate Limits](https://developer.okta.com/docs/reference/rate-limits/) -- API rate limit reference by endpoint and org type
-- [Okta Security Technical Whitepaper](https://www.okta.com/resources/whitepaper-okta-security-technical-whitepaper/) -- Okta infrastructure security, SOC 2, and compliance details
+- [Okta Trust Center](https://trust.okta.com/) -- Okta infrastructure security posture, compliance certifications, and security advisories
 - [Okta Adaptive MFA](https://help.okta.com/en-us/content/topics/security/mfa/mfa-home.htm) -- MFA factor configuration, policies, and adaptive risk scoring

--- a/knowledge/providers/okta/lifecycle-management.md
+++ b/knowledge/providers/okta/lifecycle-management.md
@@ -49,6 +49,6 @@ SCIM is the mechanism but not a guarantee. SCIM configuration that pushes new us
 
 - [Okta Universal Directory](https://help.okta.com/en-us/content/topics/directory/about-universal-directory.htm) -- profile mastering, attribute sources, and conflict handling
 - [Okta SCIM provisioning](https://developer.okta.com/docs/concepts/scim/) -- SCIM protocol, supported operations, and troubleshooting
-- [Okta group rules](https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-group-rules.htm) -- rule syntax, evaluation, and group membership updates
+- [Okta group rules](https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-group-rules-main.htm) -- rule syntax, evaluation, and group membership updates
 - [Okta Workflows](https://help.okta.com/en-us/content/topics/workflows/workflows-main.htm) -- no-code orchestration for identity events
 - [Okta import and provisioning behavior](https://help.okta.com/en-us/content/topics/directory/app-provisioning-settings.htm) -- per-app provisioning settings and their effects

--- a/knowledge/providers/okta/mfa-and-policies.md
+++ b/knowledge/providers/okta/mfa-and-policies.md
@@ -47,9 +47,9 @@ Network zones and device trust are what move the policy from "was MFA used" to "
 
 ## Reference Links
 
-- [Okta authentication policies](https://help.okta.com/en-us/content/topics/security/policies/configure-app-auth-policies.htm) -- app-level policy configuration and rule evaluation
-- [Okta FastPass](https://help.okta.com/en-us/content/topics/identity-engine/devices/fastpass-main.htm) -- passwordless, phishing-resistant primary factor
-- [Okta FIDO2 / WebAuthn](https://help.okta.com/en-us/content/topics/security/mfa/webauthn.htm) -- security-key enrollment and fallback policy
+- [Okta authentication policies](https://help.okta.com/oie/en-us/content/topics/identity-engine/policies/about-authentication-policies.htm) -- app-level policy configuration and rule evaluation
+- [Okta FastPass](https://help.okta.com/oie/en-us/content/topics/identity-engine/devices/fp/fp-main.htm) -- passwordless, phishing-resistant primary factor
+- [Okta FIDO2 / WebAuthn](https://help.okta.com/oie/en-us/content/topics/identity-engine/authenticators/phishing-resistant-auth.htm) -- security-key enrollment and fallback policy
 - [Okta ThreatInsight](https://help.okta.com/en-us/content/topics/security/threat-insight/about-threatinsight.htm) -- IP reputation, detection modes, and block configuration
 - [Okta network zones](https://help.okta.com/en-us/content/topics/security/network/network-zones.htm) -- trusted/untrusted zone configuration
-- [Okta global session policy](https://help.okta.com/en-us/content/topics/security/policies/configure-session-policy.htm) -- session duration, MFA requirements, and factor-strength rules
+- [Okta global session policy](https://help.okta.com/oie/en-us/content/topics/identity-engine/policies/about-okta-sign-on-policies.htm) -- session duration, MFA requirements, and factor-strength rules

--- a/knowledge/providers/okta/saml-and-oidc-config.md
+++ b/knowledge/providers/okta/saml-and-oidc-config.md
@@ -49,5 +49,5 @@ Session-lifetime coordination between Okta and the SP is the third cluster. User
 - [Okta SAML](https://developer.okta.com/docs/concepts/saml/) -- SAML assertion structure, signing, NameID formats
 - [Okta OIDC / OAuth 2.0](https://developer.okta.com/docs/concepts/oauth-openid/) -- OIDC client types, flows, token lifetimes
 - [Okta custom authorization servers](https://developer.okta.com/docs/concepts/auth-servers/) -- when to use the default vs a custom authorization server
-- [Okta SAML attribute statements](https://developer.okta.com/docs/guides/saml-application-setup/main/) -- attribute mapping and group filtering
-- [Okta certificate rotation](https://help.okta.com/en-us/content/topics/security/certificate-management.htm) -- signing certificate rotation and pre-rotation
+- [Okta SAML attribute statements](https://developer.okta.com/docs/guides/create-an-app-integration/saml2/main/) -- attribute mapping and group filtering
+- [Okta certificate rotation](https://help.okta.com/en-us/content/topics/apps/manage-signing-certificates.htm) -- signing certificate rotation and pre-rotation

--- a/knowledge/providers/openshift/certifications.md
+++ b/knowledge/providers/openshift/certifications.md
@@ -60,7 +60,7 @@ Red Hat certifications are entirely performance-based — candidates must comple
 ## Reference Links
 
 - [Red Hat certification portal](https://www.redhat.com/en/services/certifications) -- RHCSA, RHCE, and OpenShift certification paths and exam registration
-- [Red Hat Certified Specialist in OpenShift Administration (EX280)](https://www.redhat.com/en/services/training/ex280-red-hat-certified-specialist-in-openshift-administration-exam) -- OpenShift administration exam objectives and preparation
+- [Red Hat Certified OpenShift Administrator exam (EX280)](https://www.redhat.com/en/services/training/red-hat-certified-openshift-administrator-exam) -- OpenShift administration exam objectives and preparation (formerly "Red Hat Certified Specialist in OpenShift Administration"; exam code unchanged)
 - [Red Hat training and certification](https://www.redhat.com/en/services/training-and-certification) -- instructor-led and self-paced OpenShift training courses
 
 ## See Also

--- a/knowledge/providers/ping/identity.md
+++ b/knowledge/providers/ping/identity.md
@@ -52,10 +52,10 @@ PingDirectory's multi-master LDAP replication provides the performance needed fo
 
 ## Reference Links
 
-- [PingFederate Documentation](https://docs.pingidentity.com/pingfederate/latest/overview.html) -- PingFederate server administration, federation configuration, and adapter reference
-- [PingOne Platform Documentation](https://docs.pingidentity.com/pingone/main/p1_landing_page.html) -- PingOne cloud platform setup, SSO, MFA, and directory services
-- [PingAccess Documentation](https://docs.pingidentity.com/pingaccess/latest/overview.html) -- PingAccess deployment, policy configuration, and agent setup
-- [PingDirectory Documentation](https://docs.pingidentity.com/pingdirectory/latest/overview.html) -- PingDirectory LDAP server, replication, and performance tuning
-- [PingOne DaVinci](https://docs.pingidentity.com/davinci/latest/overview.html) -- no-code identity orchestration flows and connector catalog
+- [PingFederate Documentation](https://docs.pingidentity.com/pingfederate/) -- PingFederate server administration, federation configuration, and adapter reference
+- [PingOne Platform Documentation](https://docs.pingidentity.com/pingone/) -- PingOne cloud platform setup, SSO, MFA, and directory services
+- [PingAccess Documentation](https://docs.pingidentity.com/pingaccess/) -- PingAccess deployment, policy configuration, and agent setup
+- [PingDirectory Documentation](https://docs.pingidentity.com/pingdirectory/) -- PingDirectory LDAP server, replication, and performance tuning
+- [PingOne DaVinci](https://docs.pingidentity.com/davinci/) -- no-code identity orchestration flows and connector catalog
 - [Ping Identity Architecture Resources](https://www.pingidentity.com/en/resources.html) -- reference architectures, deployment guides, and best practices
-- [PingFederate Cluster Administration](https://docs.pingidentity.com/pingfederate/latest/administrators_reference_guide/pf_c_clusterManagement.html) -- cluster configuration, node management, and session replication
+- [PingFederate Server Clustering Guide](https://docs.pingidentity.com/pingfederate/latest/server_clustering_guide/pf_overview_cluster.html) -- cluster configuration, node management, and session replication

--- a/knowledge/providers/purestorage/flasharray.md
+++ b/knowledge/providers/purestorage/flasharray.md
@@ -46,7 +46,7 @@ The Evergreen//Forever model means the array hardware is refreshed every 3 years
 - [Pure Storage FlashArray Documentation](https://support.purestorage.com/FlashArray) — official FlashArray administration and configuration guides
 - [Purity//FA REST API Reference](https://support.purestorage.com/FlashArray/PurityFA/Purity_FA_REST_API) — REST API v2.x reference documentation
 - [ActiveCluster Design Guide](https://support.purestorage.com/Solutions/Pure_Storage_ActiveCluster) — synchronous replication architecture and requirements
-- [Pure Storage CSI Driver](https://github.com/purestorage/pso-csi) — Kubernetes CSI driver source and documentation
+- [Pure Storage Kubernetes Integration](https://support.purestorage.com/bundle/m_kubernetes/page/topics/concept/c_kubernetes.html) — Pure Service Orchestrator CSI driver deployment and Kubernetes integration guides
 - [Pure1 Meta](https://pure1.purestorage.com/) — cloud-based monitoring and analytics portal
 - [Pure Storage Ansible Collection](https://galaxy.ansible.com/purestorage/flasharray) — Ansible modules for FlashArray automation
 - [Pure Storage Terraform Provider](https://registry.terraform.io/providers/PureStorage-OpenConnect/flash/latest) — Terraform provider for infrastructure-as-code

--- a/knowledge/providers/purestorage/flashblade.md
+++ b/knowledge/providers/purestorage/flashblade.md
@@ -46,7 +46,7 @@ The //S vs //E selection significantly impacts both cost and performance. Deploy
 - [Purity//FB REST API Reference](https://support.purestorage.com/FlashBlade/Purity_FB/Purity_FB_REST_API) — REST API v2.x reference for FlashBlade automation
 - [FlashBlade S3 Object Store Guide](https://support.purestorage.com/FlashBlade/Purity_FB/FlashBlade_Object_Store) — S3-compatible object storage configuration
 - [FlashBlade Best Practices for Backup](https://support.purestorage.com/Solutions/FlashBlade/FlashBlade_Backup) — Veeam, Commvault, and other backup integration guides
-- [Pure Storage FlashBlade for AI](https://www.purestorage.com/solutions/infrastructure/ai-infrastructure.html) — AI/ML training data pipeline architecture
+- [FlashBlade for AI (AIRI with NVIDIA)](https://www.everpuredata.com/solutions/ai/nvidia.html) — AI/ML training data pipeline reference architecture
 - [Pure Storage Ansible Collection for FlashBlade](https://galaxy.ansible.com/purestorage/flashblade) — Ansible modules for FlashBlade automation
 - [FlashBlade SafeMode and Object Lock](https://support.purestorage.com/FlashBlade/Purity_FB/FlashBlade_Security) — immutable snapshots and S3 Object Lock configuration
 

--- a/knowledge/providers/purestorage/portworx.md
+++ b/knowledge/providers/purestorage/portworx.md
@@ -51,9 +51,9 @@ Portworx licensing is per-node and can become expensive at scale. The free PX-Es
 - [PX-Backup Documentation](https://docs.portworx.com/portworx-backup-on-prem/) — application-aware backup for Kubernetes
 - [PX-DR Documentation](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/disaster-recovery/) — synchronous and asynchronous disaster recovery
 - [Portworx StorageClass Parameters](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/storage-operations/create-pvcs/dynamic-provisioning/) — volume parameters including replication factor, io_profile, and encryption
-- [Stork Documentation](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/stork/) — storage orchestrator for hyperconvergence and migration
+- [Stork Documentation](https://docs.portworx.com/portworx-enterprise/deploy-your-applications/stateful-applications/stork) — storage orchestrator for hyperconvergence and migration
 - [PX-Autopilot](https://docs.portworx.com/portworx-enterprise/operations/operate-kubernetes/autopilot/) — automated capacity management rules
-- [Portworx with Pure Storage FlashArray](https://docs.portworx.com/portworx-enterprise/install-portworx/on-premises/other/pure-flash-array/) — FlashArray as backend storage for Portworx
+- [Portworx with Pure Storage FlashArray](https://docs.portworx.com/portworx-enterprise/platform/install/pure-storage/flasharray) — FlashArray as backend storage for Portworx
 
 ## See Also
 

--- a/knowledge/providers/qualys/vulnerability-management.md
+++ b/knowledge/providers/qualys/vulnerability-management.md
@@ -80,8 +80,8 @@ TruRisk scoring is Qualys's answer to the vulnerability prioritization problem. 
 
 ## Reference Links
 
-- [Qualys VMDR Documentation](https://www.qualys.com/documentation/qualys-vmdr/) -- vulnerability management, TruRisk configuration, and remediation workflows
-- [Qualys Cloud Agent Deployment Guide](https://www.qualys.com/documentation/qualys-cloud-agent/) -- agent installation, activation keys, module configuration, and proxy setup
-- [Qualys API v2 Reference](https://www.qualys.com/documentation/qualys-api/) -- bulk data export, asset management, and scan automation via REST API
-- [Qualys Container Security](https://www.qualys.com/documentation/qualys-container-security/) -- CI/CD pipeline integration, registry scanning, and runtime protection
-- [Qualys TotalCloud CNAPP](https://www.qualys.com/cloud-security/totalcloud/) -- unified cloud-native application protection platform overview
+- [Qualys VMDR Documentation](https://docs.qualys.com/en/vmdr/latest/) -- vulnerability management, TruRisk configuration, and remediation workflows
+- [Qualys Cloud Agent Documentation](https://docs.qualys.com/en/ca/latest/) -- agent installation, activation keys, module configuration, and proxy setup
+- [Qualys API Documentation (VM/PC)](https://docs.qualys.com/en/vm/api/) -- bulk data export, asset management, and scan automation via the Qualys API
+- [Qualys Container Security](https://docs.qualys.com/en/cs/latest/) -- CI/CD pipeline integration, registry scanning, and runtime protection
+- [Qualys TotalCloud CNAPP](https://www.qualys.com/apps/totalcloud) -- unified cloud-native application protection platform overview

--- a/knowledge/providers/servicenow/cmdb.md
+++ b/knowledge/providers/servicenow/cmdb.md
@@ -63,7 +63,7 @@ Cloud Discovery is the area where the CMDB design most often falls behind the ac
 The following links point to ServiceNow public documentation. ServiceNow gates a portion of its product documentation behind a customer login; verify the current URL and bundle name against the customer's release (Yokohama, Zurich, etc.) before relying on a specific page.
 
 - [ServiceNow CMDB product page](https://www.servicenow.com/products/servicenow-platform/configuration-management-database.html) -- CMDB product positioning, CSDM, and related modules
-- [Common Service Data Model (CSDM)](https://www.servicenow.com/community/csdm/csdm-overview/) -- CSDM four-layer model, application service vs technical service vs service offering
+- [Common Service Data Model (CSDM)](https://www.servicenow.com/docs/r/servicenow-platform/common-service-data-model-csdm/csdm-landing-page.html) -- CSDM four-layer model, application service vs technical service vs service offering
 - [ServiceNow Discovery](https://www.servicenow.com/products/discovery.html) -- agentless discovery, MID Server, Patterns, Cloud Discovery
 - [ServiceNow Service Mapping](https://www.servicenow.com/products/service-mapping.html) -- top-down service mapping, ML mapping, Service Graph Connectors
 - [ServiceNow Developer Portal](https://developer.servicenow.com/) -- CMDB schema, IRE configuration, CI class extension, and Pattern Designer references

--- a/knowledge/providers/solarwinds/monitoring.md
+++ b/knowledge/providers/solarwinds/monitoring.md
@@ -48,6 +48,6 @@ Note: SolarWinds' AI capabilities are less mature than Datadog or Splunk. Organi
 
 ## Reference Links
 
-- [SolarWinds Orion Platform Documentation](https://documentation.solarwinds.com/en/success_center/orionplatform/content/core-orion-introduction.htm) -- NPM, SAM, VMAN, NCM modules and polling engine architecture
-- [SolarWinds Observability (SaaS)](https://documentation.solarwinds.com/en/success_center/observability/content/intro/introduction.htm) -- cloud-native monitoring platform for hybrid environments
-- [SolarWinds Sizing Guide](https://documentation.solarwinds.com/en/success_center/orionplatform/content/core-orion-requirements.htm) -- polling engine sizing, database requirements, and distributed architecture
+- [SolarWinds Platform documentation (formerly Orion Platform)](https://documentation.solarwinds.com/en/success_center/orionplatform/content/orion_platform_documentation.htm) -- NPM, SAM, VMAN, NCM modules and polling engine architecture
+- [SolarWinds Observability SaaS documentation](https://documentation.solarwinds.com/en/success_center/observability/content/observability_documentation.htm) -- cloud-native monitoring platform for hybrid environments
+- [SolarWinds Platform deployment sizing guidelines](https://documentation.solarwinds.com/en/success_center/orionplatform/content/core-multi-module-system-guidelines.htm) -- polling engine sizing, database requirements, and distributed architecture

--- a/knowledge/providers/vmware/aria-suite.md
+++ b/knowledge/providers/vmware/aria-suite.md
@@ -64,7 +64,7 @@ Finally, the deployment-model question (on-prem vs SaaS vs hybrid) has changed c
 
 ## Reference Links
 
-- [VMware Cloud Foundation on Broadcom](https://www.broadcom.com/products/software/vmware-cloud-foundation) -- current VCF product page including which suite components are bundled
+- [VMware Cloud Foundation product page](https://www.vmware.com/products/cloud-infrastructure/vmware-cloud-foundation) -- current VCF product page including which suite components are bundled
 - [Broadcom TechDocs portal](https://techdocs.broadcom.com/) -- post-acquisition consolidated documentation home; the former docs.vmware.com URLs for vRealize and Aria products now redirect here
 - [VMware end-of-life lifecycle matrix](https://lifecycle.vmware.com/) -- vRealize and Aria product end-of-support dates relevant to renewal planning
 

--- a/knowledge/providers/vmware/data-protection.md
+++ b/knowledge/providers/vmware/data-protection.md
@@ -39,7 +39,7 @@ Data protection failures are discovered at the worst possible time -- during rec
 
 - [vSphere Replication documentation](https://docs.vmware.com/en/vSphere-Replication/index.html) -- vSphere Replication deployment, configuration, and recovery point objectives
 - [VCF Live Site Recovery documentation](https://docs.vmware.com/en/VMware-Cloud-Foundation/services/vcf-live-site-recovery/GUID-E8C21E2B-7C03-4E0C-8113-4F2E0A3B2E6A.html) -- orchestrated disaster recovery with recovery plans and automated failover
-- [vSphere Storage APIs for Data Protection (VADP)](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-storage-guide/backing-up-virtual-machines/vstorage-apis-for-data-protection.html) -- VADP and Changed Block Tracking for backup integration
+- [Virtual Disk Development Kit (VDDK) Programming Guide](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere-sdks-tools/8-0/virtual-disk-development-kit-programming-guide.html) -- the canonical reference for vSphere Storage APIs for Data Protection (VADP) and Changed Block Tracking in backup integration
 
 ## See Also
 

--- a/knowledge/providers/vmware/gcve-gcp.md
+++ b/knowledge/providers/vmware/gcve-gcp.md
@@ -64,7 +64,7 @@ GCVE is the ideal path to GCP for organizations with VMware estates needing prox
 
 - [Google Cloud VMware Engine documentation](https://cloud.google.com/vmware-engine/docs) -- official GCVE deployment, networking, and private cloud management
 - [GCVE pricing](https://cloud.google.com/vmware-engine/pricing) -- node pricing, committed use discounts, and cost estimation
-- [GCVE network architecture](https://cloud.google.com/vmware-engine/docs/concepts-network-architecture) -- Private Service Access, VPC peering, and connectivity design
+- [About VMware Engine networks](https://cloud.google.com/vmware-engine/docs/networking/vmware-engine-network) -- standard vs legacy networks, VPC Network Peering, Private Service Access, and connectivity design
 
 ## See Also
 

--- a/knowledge/providers/vmware/horizon.md
+++ b/knowledge/providers/vmware/horizon.md
@@ -39,8 +39,8 @@ The Broadcom acquisition has significantly impacted Horizon licensing and roadma
 ## Reference Links
 
 - [VMware Horizon documentation](https://docs.vmware.com/en/VMware-Horizon/index.html) -- Connection Server, UAG, instant clones, and desktop pool configuration
-- [Horizon architecture planning guide](https://techdocs.broadcom.com/us/en/vmware-end-user-computing/horizon/horizon/2406/horizon-architecture-planning.html) -- sizing, pod architecture, and protocol selection
-- [VMware Horizon reference architecture](https://techdocs.broadcom.com/us/en/vmware-end-user-computing/horizon/horizon/2406/horizon-architecture-planning/horizon-reference-architecture.html) -- reference deployment topologies for Horizon environments
+- [Horizon overview and deployment planning guide](https://docs.omnissa.com/bundle/HorizonOverviewDeployment/page/HorizonOverviewandDeploymentPlanning.html) -- sizing, pod architecture, and protocol selection (Horizon docs moved to Omnissa after the VMware EUC divestiture)
+- [Omnissa Workspace ONE and Horizon reference architecture](https://techzone.omnissa.com/reference-architecture) -- reference deployment topologies for Horizon environments
 
 ## See Also
 

--- a/knowledge/providers/vmware/licensing.md
+++ b/knowledge/providers/vmware/licensing.md
@@ -493,7 +493,7 @@ Alternative Platform TCO (3-5 Year):
 
 ## Reference Links
 
-- [Broadcom VMware product portfolio](https://www.broadcom.com/products/software/vmware-cloud-foundation) -- VCF and VVF edition details, included components, and subscription information
+- [VCF 9.0 offerings and components](https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/licensing/licensing-overview/offerings-and-components.html) -- VCF and VVF edition details, included components, and subscription information
 - [VMware Cloud Foundation documentation](https://docs.vmware.com/en/VMware-Cloud-Foundation/index.html) -- VCF lifecycle management, edition comparison, and component bundling
 - [VMware end-of-life lifecycle matrix](https://lifecycle.vmware.com/) -- vSphere, vSAN, NSX end-of-support dates and lifecycle policies
 

--- a/knowledge/providers/vmware/security.md
+++ b/knowledge/providers/vmware/security.md
@@ -36,7 +36,7 @@ VMware environments are high-value targets because compromising vCenter or ESXi 
 
 ## Reference Links
 
-- [vSphere Security Configuration Guide](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere-security-configuration-guide/8-0/about-this-guide.html) -- ESXi and vCenter hardening baselines (formerly Hardening Guide)
+- [vSphere Security Configuration Guide](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/vsphere-security/understanding-vsphere-hardening-and-compliance/understanding-vsphere-security-configuration-guide.html) -- ESXi and vCenter hardening baselines (formerly Hardening Guide)
 - [vSphere security guide](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-security/GUID-52188148-C579-4F6A-8335-CFBCE0DD2167.html) -- encryption, key management, RBAC, certificate management, and audit logging
 - [NSX security documentation](https://docs.vmware.com/en/VMware-NSX/4.2/administration/GUID-31A2D4B8-42A0-4D0F-8B85-1E3C42DD93E6.html) -- distributed firewall, microsegmentation, and IDS/IPS configuration
 

--- a/knowledge/providers/vmware/storage.md
+++ b/knowledge/providers/vmware/storage.md
@@ -69,7 +69,7 @@ Storage is the most common bottleneck and the most consequential failure domain 
 
 - [vSAN documentation](https://docs.vmware.com/en/VMware-vSAN/index.html) -- vSAN OSA and ESA deployment, storage policies, and capacity planning
 - [vSphere storage guide](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-storage/GUID-8AE88758-20C1-4873-99C7-181EF9ACFA70.html) -- VMFS, NFS, vVols, SPBM, and Storage DRS configuration
-- [vSAN design guide](https://techdocs.broadcom.com/us/en/vmware-cis/vsan/vsan/8-0/vsan-planning-and-deployment-guide-80/planning-and-designing-a-vsan-cluster.html) -- cluster sizing, disk group design, and fault domain configuration
+- [vSAN design guide](https://techdocs.broadcom.com/us/en/vmware-cis/vsan/vsan/8-0/planning-and-deployment/designing-and-sizing-a-virtual-san-cluster.html) -- cluster sizing, disk group design, and fault domain configuration
 
 ## See Also
 


### PR DESCRIPTION
Closes #315.

## What changed

97 dead external links repaired across 66 knowledge files. Two links removed rather than replaced (content consolidated into an already-cited adjacent line); three expanded to several where a vendor split one guide into per-topic guides.

## The count moved from 117 to 98, and that matters

The original 117 came from a checker using a **self-identifying bot user-agent**. Google and several vendor sites serve bots a 301/404 while serving browsers a 200. Nineteen of the 117 were that measurement artifact — fixing them would have rewritten 19 perfectly good citations.

This is the same conflation `#298` made when it reported "251 failed" by lumping DEAD (404/410) together with BLOCKED (403/429 anti-bot) and UNREACHABLE (timeouts). The repo has now made that error twice. **Any future link audit must use a browser UA and must separate dead from blocked.**

## Verification

All 96 replacement URLs were re-verified **independently of the four agents that authored them** — host-serialised, browser UA, with a soft-404 check for redirects landing on a site root.

- 95/96 returned 2xx/3xx
- 0 soft-404 redirect drift
- The single non-200 is `dell.com/support/kbdoc/000126599`, which serves a blanket 403 to curl regardless of UA; WebFetch confirms it loads real content

## Deliberate non-changes

- **`token.actions.githubusercontent.com`** is not a documentation link — it is the GitHub Actions OIDC *issuer identifier* inside workload-identity configuration. The bare host 404s by design; `/.well-known/openid-configuration` returns 200. Rewriting it would break the command. Appears in both the GCP and Azure federated-identity pages.
- **`registry-1.docker.io`** likewise 404s at `/` and returns 401 at `/v2/` by design.

## Vendor reorganisations found (these will recur)

| vendor | what happened |
|---|---|
| **Pure Storage** | rebranded to **Everpure**; `purestorage.com` → `everpuredata.com`. The domain redirect works so links still pass a checker, but deep product paths were reorganised. **A domain sweep is coming.** |
| **VMware EUC** | Horizon / Workspace ONE / App Volumes / DEM / UAG left Broadcom in the 2024 divestiture → `docs.omnissa.com`. Note `docs.vmware.com/en/VMware-Horizon/index.html` still returns 200 but lands on the Omnissa home page — a soft-404 no status-code check catches. |
| **Morpheus** | docs now redirect to `hpe.com` post-acquisition |
| **whitehouse.gov** | Biden-era `/briefing-room/*` gone with no redirects; cite the Federal Register for executive orders |
| **NIST CSRC** | `/publications/detail/sp/NNN/revN/final` → `/pubs/sp/NNN/rN/final` (mechanical) |
| **IBM** | support slugs encode a revision date and die on every refresh; `/support/pages/node/<id>` is the stable alias |
| **sigstore** | `/cosign/overview/` redirects *into* a 404 — a redirect-following checker reports it dead at the wrong URL |

## Hosts where status code alone proves nothing

`dell.com/support/*`, `lenovo.com`, `netapp.com`, `community.citrix.com`, and `infohub.delltechnologies.com` (200 + reCAPTCHA interstitial) 403 all non-browser traffic. **On these, 404 means dead but 403 means nothing — do not "fix" a 403.**

## Note on the commit message

The pre-commit guard blocked the first attempt: one vendor's name in the "reorganisations" list matches a confidential client pattern. `knowledge/**` is exempt from client-name scanning — which is why the affected page exists at all — but a commit message has no path, so the exemption cannot apply. The message was rephrased rather than overridden. **The guard behaved correctly.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)