### PR TITLE
fix(hooks): resolve client-patterns.local from the primary clone in worktrees

### DIFF
--- a/.githooks/guard-lib.sh
+++ b/.githooks/guard-lib.sh
@@ -32,6 +32,28 @@ RED=$'\033[31m'; YEL=$'\033[33m'; GRN=$'\033[32m'; DIM=$'\033[2m'; NC=$'\033[0m'
 HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLIENT_PATTERNS_FILE="$HOOKS_DIR/client-patterns.local"
 
+# WORKTREE FALLBACK.
+# `client-patterns.local` is gitignored (it names real clients), so it is NEVER
+# present in a linked worktree — `git worktree add` only materialises tracked
+# files. The result was that the CLIENT-DATA guard, this repo's #1 rule, was
+# silently OFF in every worktree while credential scanning kept working, so the
+# hooks still ran and still passed. It warns, but a warning that appears on every
+# commit in a worktree is a warning nobody reads.
+#
+# Resolve the primary clone through the SHARED git dir and reuse its copy.
+# `--git-common-dir` returns the real .git for a linked worktree and plain `.git`
+# for the primary one, so the primary case is a no-op that re-finds the same file.
+if [ ! -f "$CLIENT_PATTERNS_FILE" ]; then
+  _gcd="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+  if [ -n "$_gcd" ]; then
+    _main="$(cd "$(dirname "$_gcd")" 2>/dev/null && pwd || true)"
+    if [ -n "$_main" ] && [ -f "$_main/.githooks/client-patterns.local" ]; then
+      CLIENT_PATTERNS_FILE="$_main/.githooks/client-patterns.local"
+    fi
+  fi
+  unset _gcd _main
+fi
+
 # ---------- credential patterns (versioned; safe to publish) ----------
 # Shapes only — no secret is embedded here.
 CRED_PATTERNS=(


### PR DESCRIPTION
## The bug

**The CLIENT-DATA guard has been silently OFF in every linked worktree.** This repo is public and client-data leakage is its stated #1 rule, so this is the guard that matters most.

`client-patterns.local` is gitignored because it names real clients. That is correct — and it is also why `git worktree add` never creates it, since worktree creation only checks out *tracked* files. So every worktree started with no pattern file, `client_regex()` returned failure, and `scan_text_for_client_data()` degraded to a no-op returning "clean".

**Credential scanning kept working**, so the hooks still ran and still passed on every commit. That is what made this invisible.

The library did warn on every commit. But a warning that appears on every commit in a worktree is a warning nobody reads — **eleven worktrees created in a single session all committed with the guard disabled** before it was noticed.

## The fix

When the local file is absent, resolve the primary clone through the **shared** git dir and reuse its copy. `git rev-parse --git-common-dir` returns the real `.git` for a linked worktree and plain `.git` for the primary one, so the primary case re-finds the same file and is a no-op.

## Verified three ways

| case | before | after |
|---|---|---|
| primary clone | 19 patterns loaded | 19 patterns loaded (unchanged) |
| **linked worktree** | **guard off, scan returns clean** | 19 patterns loaded; `scan_text_for_client_data` **demonstrably blocks** a line built from a real pattern |
| no copy anywhere | `client_regex` fails, caller warns | unchanged — deliberately |

That last row is the important one. The fallback must not convert "no patterns anywhere" into false confidence, so a genuinely missing file still fails and still warns.

## Scope

Deliberately unchanged: credential scanning never consulted the client pattern file and was never affected; the `knowledge/**` and `mkdocs.yml` exemption for client-name scanning is untouched; and a commit **message** has no path, so it is still scanned with no exemption available — which is why a commit message was correctly blocked earlier in this session while the same vendor name was permitted inside a `knowledge/` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)