### PR TITLE
feat(knowledge): regulated FS data platform reference architecture (#238)

### DIFF
--- a/knowledge/assets/regulated-fs-data-platform.svg
+++ b/knowledge/assets/regulated-fs-data-platform.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1720" height="960" viewBox="0 0 1720 960" font-family="Helvetica,Arial,sans-serif">
+<defs><marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#9fb3c8"/></marker></defs>
+<rect width="1720" height="960" fill="#ffffff"/>
+<text x="46" y="52" font-size="25" font-weight="700" fill="#14304f" text-anchor="start">Regulated financial services — data platform reference architecture</text>
+<text x="46" y="78" font-size="13.5" font-weight="400" fill="#6b7f95" text-anchor="start">A pattern for institutions under examination, where retention, lineage and evidence are design inputs rather than afterthoughts.</text>
+<line x1="46" y1="96" x2="1674" y2="96" stroke="#9fb3c8" stroke-width="1"/>
+<rect x="46" y="130" width="250" height="132" rx="7" fill="#eef3f8" stroke="#9fb3c8" stroke-width="1.6"/>
+<text x="60" y="154" font-size="15" font-weight="700" fill="#14304f">Systems of record</text>
+<text x="60" y="172" font-size="12" fill="#6b7f95">core banking · nightly batch</text>
+<text x="62" y="192" font-size="12.5" fill="#2c4a6b">Core banking platform</text>
+<text x="62" y="209" font-size="12.5" fill="#2c4a6b">Loan servicing</text>
+<text x="62" y="226" font-size="12.5" fill="#2c4a6b">Card / payments</text>
+<text x="62" y="243" font-size="12.5" fill="#2c4a6b">GL</text>
+<rect x="46" y="276" width="250" height="132" rx="7" fill="#eef3f8" stroke="#9fb3c8" stroke-width="1.6"/>
+<text x="60" y="300" font-size="15" font-weight="700" fill="#14304f">Risk, lending, compliance</text>
+<text x="60" y="318" font-size="12" fill="#6b7f95">batch / API · daily</text>
+<text x="62" y="338" font-size="12.5" fill="#2c4a6b">Loan origination</text>
+<text x="62" y="355" font-size="12.5" fill="#2c4a6b">Credit / ALLL</text>
+<text x="62" y="372" font-size="12.5" fill="#2c4a6b">Fraud &amp; AML</text>
+<text x="62" y="389" font-size="12.5" fill="#2c4a6b">Mortgage</text>
+<rect x="46" y="422" width="250" height="92" rx="7" fill="#fdf5e6" stroke="#b07d1a" stroke-width="1.6" stroke-dasharray="6 4"/>
+<text x="60" y="446" font-size="15" font-weight="700" fill="#14304f">Content &amp; file shares</text>
+<text x="60" y="464" font-size="12" fill="#6b7f95">DEFER past phase one</text>
+<text x="62" y="484" font-size="12.5" fill="#2c4a6b">Document &amp; file stores</text>
+<text x="46" y="540" font-size="13.5" font-weight="700" fill="#b03535" text-anchor="start">Extraction constraints</text>
+<text x="54" y="562" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">• Batch windows and end-of-day cycles</text>
+<text x="54" y="579" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">• Per-extract / per-record access charges</text>
+<text x="54" y="596" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">• Contract terms on data leaving the vendor</text>
+<text x="54" y="613" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">• Log-based CDC usually unavailable</text>
+<rect x="330" y="130" width="232" height="250" rx="7" fill="#e6f4ec" stroke="#2e7d52" stroke-width="1.6"/>
+<text x="344" y="154" font-size="15" font-weight="700" fill="#14304f">Immutable landing zone</text>
+<text x="344" y="172" font-size="12" fill="#6b7f95">NEW — raw, as received</text>
+<text x="346" y="192" font-size="12.5" fill="#2c4a6b">Object storage with a lock</text>
+<text x="346" y="209" font-size="12.5" fill="#2c4a6b">policy — WORM / legal hold</text>
+<text x="346" y="226" font-size="12.5" fill="#2c4a6b"></text>
+<text x="346" y="243" font-size="12.5" fill="#2c4a6b">Never rewritten, never</text>
+<text x="346" y="260" font-size="12.5" fill="#2c4a6b">compacted, never modelled</text>
+<text x="346" y="277" font-size="12.5" fill="#2c4a6b"></text>
+<text x="346" y="294" font-size="12.5" fill="#2c4a6b">This is what retention and</text>
+<text x="346" y="311" font-size="12.5" fill="#2c4a6b">replay actually attach to</text>
+<line x1="300" y1="192" x2="326" y2="202" stroke="#9fb3c8" stroke-width="1.8" marker-end="url(#ah)"/>
+<line x1="300" y1="336" x2="326" y2="282" stroke="#9fb3c8" stroke-width="1.8" marker-end="url(#ah)"/>
+<text x="330" y="416" font-size="13.5" font-weight="700" fill="#2e7d52" text-anchor="start">Why this layer earns its place</text>
+<text x="338" y="438" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">• Retention and legal hold become enforceable</text>
+<text x="338" y="455" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">• The lakehouse can be rebuilt from source</text>
+<text x="338" y="472" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">• History survives a change of model</text>
+<text x="338" y="489" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">• WORM needs care on HNS accounts</text>
+<rect x="596" y="130" width="196" height="116" rx="7" fill="#eef3f8" stroke="#9fb3c8" stroke-width="1.6"/>
+<text x="610" y="154" font-size="15" font-weight="700" fill="#14304f">Ingestion &amp; orchestration</text>
+<text x="612" y="174" font-size="12.5" fill="#2c4a6b">Batch pipelines</text>
+<text x="612" y="191" font-size="12.5" fill="#2c4a6b">CDC / replication</text>
+<text x="612" y="208" font-size="12.5" fill="#2c4a6b">Managed mirroring</text>
+<rect x="596" y="260" width="214" height="74" rx="7" fill="#fdf5e6" stroke="#b07d1a" stroke-width="1.6" stroke-dasharray="6 4"/>
+<text x="610" y="284" font-size="15" font-weight="700" fill="#14304f">Streaming ingestion</text>
+<text x="610" y="302" font-size="12" fill="#6b7f95">DEFER — fraud/AML covered</text>
+<line x1="562" y1="250" x2="596" y2="188" stroke="#9fb3c8" stroke-width="1.8" marker-end="url(#ah)"/>
+<text x="596" y="366" font-size="13.5" font-weight="700" fill="#b03535" text-anchor="start">State the as-of grain</text>
+<text x="604" y="388" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">If the core delivers nightly</text>
+<text x="604" y="405" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">extracts, the estate has a</text>
+<text x="604" y="422" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">DAILY grain. Say so as a</text>
+<text x="604" y="439" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">design decision.</text>
+<rect x="812" y="114" width="368" height="454" rx="12" fill="#f7f9fb" stroke="#9fb3c8" stroke-width="1.4" stroke-dasharray="7 5"/>
+<text x="824" y="134" font-size="13" font-weight="700" fill="#14304f" text-anchor="start">Lakehouse — isolated workspace</text>
+<rect x="826" y="152" width="340" height="74" rx="7" fill="#e8d3bd" stroke="#b08d63" stroke-width="1.6"/>
+<text x="840" y="176" font-size="15" font-weight="700" fill="#14304f">Bronze — raw tables</text>
+<text x="840" y="194" font-size="12" fill="#6b7f95">loaded from the landing zone, not from source</text>
+<rect x="826" y="240" width="340" height="92" rx="7" fill="#dfe6ed" stroke="#a9b6c2" stroke-width="1.6"/>
+<text x="840" y="264" font-size="15" font-weight="700" fill="#14304f">Silver — curated &amp; conformed</text>
+<text x="840" y="282" font-size="12" fill="#6b7f95">standardised datasets, quality rules</text>
+<rect x="826" y="346" width="340" height="96" rx="7" fill="#f6e3b4" stroke="#c9a94e" stroke-width="1.6"/>
+<text x="840" y="370" font-size="15" font-weight="700" fill="#14304f">Gold — business ready</text>
+<text x="840" y="388" font-size="12" fill="#6b7f95">metrics, KPIs, regulatory outputs</text>
+<line x1="996.0" y1="226" x2="996.0" y2="238" stroke="#9fb3c8" stroke-width="1.8" marker-end="url(#ah)"/>
+<line x1="996.0" y1="332" x2="996.0" y2="344" stroke="#9fb3c8" stroke-width="1.8" marker-end="url(#ah)"/>
+<line x1="792" y1="188" x2="826" y2="188" stroke="#9fb3c8" stroke-width="1.8" marker-end="url(#ah)"/>
+<rect x="826" y="460" width="340" height="88" rx="7" fill="#fdecec" stroke="#b03535" stroke-width="1.6"/>
+<text x="840" y="484" font-size="15" font-weight="700" fill="#14304f">General ledger reconciliation</text>
+<text x="840" y="502" font-size="12" fill="#6b7f95">control totals · tie-out · sign-off</text>
+<text x="842" y="522" font-size="12.5" fill="#2c4a6b">No number is trusted until it ties to the GL</text>
+<line x1="996.0" y1="442" x2="996.0" y2="458" stroke="#9fb3c8" stroke-width="1.8" marker-end="url(#ah)"/>
+<rect x="826" y="592" width="340" height="122" rx="7" fill="#f2ecfa" stroke="#6a4c93" stroke-width="1.6"/>
+<text x="840" y="616" font-size="15" font-weight="700" fill="#14304f">Customer &amp; account resolution</text>
+<text x="840" y="634" font-size="12" fill="#6b7f95">SEPARATE WORKSTREAM — own budget, own owner</text>
+<text x="842" y="654" font-size="12.5" fill="#2c4a6b">Entity resolution across source systems</text>
+<text x="842" y="671" font-size="12.5" fill="#2c4a6b">Survivorship rules — which source wins</text>
+<text x="842" y="688" font-size="12.5" fill="#2c4a6b">Stewardship queue for exceptions</text>
+<text x="842" y="705" font-size="12.5" fill="#2c4a6b">Not a transformation step. Size it separately.</text>
+<line x1="996.0" y1="592" x2="996.0" y2="570" stroke="#6a4c93" stroke-width="2" stroke-dasharray="5 4" marker-end="url(#ah)"/>
+<text x="1006.0" y="580" font-size="11.5" font-weight="400" fill="#6a4c93" text-anchor="start">produces the conformed dimensions in Silver</text>
+<rect x="1186" y="114" width="278" height="288" rx="12" fill="#f7f9fb" stroke="#2e7d52" stroke-width="1.6" stroke-dasharray="7 5"/>
+<text x="1198" y="134" font-size="13" font-weight="700" fill="#2e7d52" text-anchor="start">Serving workspace — separate</text>
+<rect x="1200" y="152" width="250" height="112" rx="7" fill="#e6f4ec" stroke="#2e7d52" stroke-width="1.6"/>
+<text x="1214" y="176" font-size="15" font-weight="700" fill="#14304f">Semantic layer</text>
+<text x="1214" y="194" font-size="12" fill="#6b7f95">governed metric definitions</text>
+<text x="1216" y="214" font-size="12.5" fill="#2c4a6b">Kept outside the isolated</text>
+<text x="1216" y="231" font-size="12.5" fill="#2c4a6b">workspace where platform</text>
+<text x="1216" y="248" font-size="12.5" fill="#2c4a6b">constraints require it.</text>
+<rect x="1200" y="280" width="250" height="100" rx="7" fill="#eef3f8" stroke="#9fb3c8" stroke-width="1.6"/>
+<text x="1214" y="304" font-size="15" font-weight="700" fill="#14304f">Reporting &amp; analytics</text>
+<text x="1216" y="324" font-size="12.5" fill="#2c4a6b">Dashboards &amp; reporting</text>
+<text x="1216" y="341" font-size="12.5" fill="#2c4a6b">Regulatory outputs</text>
+<text x="1216" y="358" font-size="12.5" fill="#2c4a6b">ML / predictive (later phase)</text>
+<line x1="1166" y1="280" x2="1200" y2="200" stroke="#9fb3c8" stroke-width="1.8" marker-end="url(#ah)"/>
+<line x1="1325.0" y1="264" x2="1325.0" y2="278" stroke="#9fb3c8" stroke-width="1.8" marker-end="url(#ah)"/>
+<text x="1200" y="448" font-size="13.5" font-weight="700" fill="#14304f" text-anchor="start">Consumers</text>
+<text x="1208" y="470" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">Below a capacity threshold each</text>
+<text x="1208" y="487" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">viewer needs a per-user licence —</text>
+<text x="1208" y="504" font-size="12" font-weight="400" fill="#6b7f95" text-anchor="start">cost this before it is discovered.</text>
+<rect x="46" y="806" width="1628" height="96" rx="10" fill="#f7f9fb" stroke="#9fb3c8" stroke-width="1.6"/>
+<text x="62" y="834" font-size="15" font-weight="700" fill="#14304f" text-anchor="start">Governance, security &amp; evidence — spans every layer</text>
+<text x="62" y="862" font-size="12.5" font-weight="600" fill="#2c4a6b" text-anchor="start">Catalog &amp; lineage</text>
+<text x="330" y="862" font-size="12.5" font-weight="600" fill="#2c4a6b" text-anchor="start">Classification &amp; labels</text>
+<text x="598" y="862" font-size="12.5" font-weight="600" fill="#2c4a6b" text-anchor="start">RBAC, row/column security</text>
+<text x="866" y="862" font-size="12.5" font-weight="600" fill="#2c4a6b" text-anchor="start">Audit logging</text>
+<text x="1134" y="862" font-size="12.5" font-weight="600" fill="#2c4a6b" text-anchor="start">Data quality</text>
+<text x="1402" y="862" font-size="12.5" font-weight="600" fill="#2c4a6b" text-anchor="start">Retention &amp; legal hold</text>
+<text x="1402" y="880" font-size="11.5" font-weight="600" fill="#2e7d52" text-anchor="start">anchored to the landing zone</text>
+<text x="62" y="880" font-size="11.5" font-weight="400" fill="#6b7f95" text-anchor="start">column-level lineage is what answers “where did this number come from”</text>
+<text x="46" y="934" font-size="11.5" font-weight="400" fill="#6b7f95" text-anchor="start">A pattern, not a product. Verify every platform constraint against current vendor documentation before relying on it.</text>
+</svg>

--- a/knowledge/patterns/regulated-fs-reference-architecture.md
+++ b/knowledge/patterns/regulated-fs-reference-architecture.md
@@ -1,0 +1,104 @@
+# Regulated Financial Services — Data Platform Reference Architecture
+
+## Scope
+
+A worked reference architecture for a data platform inside an examined financial institution, where
+retention, lineage and evidence are design inputs rather than things added afterwards. Covers the
+layer topology, what each layer is accountable for, and the four decisions that are routinely made
+implicitly and should be made explicitly.
+
+This is a **pattern, not a product**. It names no vendor and no institution. For platform selection
+see `patterns/data-platform-selection.md`; for the constraints that shape it see
+`patterns/regulated-financial-data-platform.md` and `compliance/ffiec.md`.
+
+![Regulated financial services data platform reference architecture](../assets/regulated-fs-data-platform.svg)
+
+## Checklist
+
+### Landing and raw
+
+- [ ] **[Critical]** Is there an **immutable landing zone distinct from the lakehouse bronze layer** — object storage under a lock policy, holding source data exactly as received? Bronze in a table format is rewritten by compaction, snapshot expiry and file maintenance, so it cannot be the thing a retention schedule or a legal hold attaches to. Without a separate landing zone, "we retain everything" is an assertion the storage layer does not support.
+- [ ] **[Critical]** Can the entire lakehouse be **rebuilt from the landing zone** without going back to the source systems? This is what makes a modelling mistake recoverable, and it is the only defence against a source system that no longer holds the history.
+- [ ] **[Critical]** Have you confirmed that your object store's **immutability features work on the account type the lake actually uses**? Version-level WORM and hierarchical-namespace accounts interact badly on at least one major cloud, and the failure is silent — the policy appears set and does not apply.
+- [ ] **[Recommended]** Is the landing zone written **before** any transformation, including trivial ones? A "light cleanup on ingest" is a transformation, and it destroys the property the layer exists to provide.
+
+### Grain and reconciliation
+
+- [ ] **[Critical]** Is the **as-of grain stated explicitly** for every source? If the system of record delivers a nightly extract, the estate has a daily grain, and downstream expectations should be set against that rather than against the architecture diagram's streaming arrows.
+- [ ] **[Critical]** Does every reported figure **reconcile to the general ledger**, with control totals and a named sign-off? For a financial institution this is the acceptance criterion. A platform that produces fast numbers nobody will certify has not delivered.
+- [ ] **[Recommended]** Is there a documented position on **intraday versus end-of-day state**, including memo-post versus posted? Many core systems cannot answer intraday questions at all, and discovering that after the semantic model is built is expensive.
+
+### Identity resolution
+
+- [ ] **[Critical]** Is customer and account resolution scoped as a **separate workstream with its own budget line and business owner**, rather than as a transformation step inside the curated layer? Drawn as a layer it gets estimated as a layer. See `general/master-data-management.md` and `patterns/entity-resolution.md`.
+- [ ] **[Critical]** Are **survivorship rules** — which source wins, per attribute — decided by the business rather than defaulted by the tool?
+- [ ] **[Recommended]** Is there a **stewardship queue** with an owner and an SLA, and a defined behaviour for downstream consumers while a conflict is unresolved?
+
+### Isolation and serving
+
+- [ ] **[Critical]** Have you enumerated which platform features are **unavailable inside a network-isolated workspace**? On at least one major platform the semantic-model layer cannot coexist with workspace-level private networking, which forces a serving workspace split that is far cheaper to design in than to retrofit.
+- [ ] **[Critical]** Is **open-format portability actually available under your network configuration**? Catalog interoperability is commonly disabled when private networking is enabled, which means the portability argument and the isolation argument cannot both be made.
+- [ ] **[Recommended]** Is the **per-consumer licensing cliff** modelled? Several platforms shift from capacity-based to per-user licensing below a capacity threshold, which changes the cost of a wide reporting rollout substantially.
+
+### Governance as evidence
+
+- [ ] **[Critical]** Is lineage sufficient to answer **"where did this number come from"** for a specific reported figure — which usually means column-level, not table-level?
+- [ ] **[Critical]** Are retention and legal hold **anchored to the landing zone** rather than to the lakehouse tables?
+- [ ] **[Recommended]** Can you produce **evidence on demand** — access reviews, key custody, retention enforcement — rather than reconstructing it when asked?
+
+## Why This Matters
+
+Most data platform designs are drawn for the happy path: sources on the left, layers in the middle,
+dashboards on the right. In an examined institution, three of the four hardest questions are about
+things that do not appear on that drawing — where the raw record lives, what the numbers reconcile
+to, and what evidence exists that controls operate.
+
+The architecture above differs from a generic medallion diagram in four specific ways, and each one
+corresponds to a failure that is expensive to fix later:
+
+**A separate immutable landing zone**, because a table-format layer is rewritten as a matter of
+routine maintenance and cannot carry a retention obligation.
+
+**Identity resolution as a workstream**, because when it is drawn as a layer it is estimated as a
+layer — and in a post-merger or multi-source estate it is frequently the largest single body of
+work in the programme.
+
+**Reconciliation as an explicit control point**, because the acceptance criterion is trust, not
+latency.
+
+**A serving layer drawn outside the isolated workspace**, because platform constraints on network
+isolation routinely make the two incompatible, and discovering that during implementation forces a
+redesign of the consumption tier.
+
+## Common Decisions (ADR Triggers)
+
+- Landing zone in the same cloud as the lakehouse, or deliberately elsewhere for concentration risk
+- Retention enforced by storage policy versus by catalog policy
+- Whether the curated layer is rebuilt from landing on every material model change
+- Whether identity resolution runs before or after the curated layer
+- Serving workspace topology, and which side of the network boundary the semantic layer sits on
+- Streaming ingestion in phase one, or deferred until a real-time consumer exists that is not already served by an operational system
+
+## Reference Architectures
+
+The diagram above is the base pattern. Two common variants:
+
+**Deferred streaming.** Phase one is batch only, with the streaming path drawn but not built. This
+is the right default when the genuine real-time use cases — fraud and AML monitoring — are already
+served by an operational system, since duplicating them into the lake adds cost without adding
+capability.
+
+**Split serving.** Where platform constraints prevent the semantic layer from living inside the
+isolated workspace, the serving tier moves to a second workspace with its own access model. This
+should be a deliberate choice recorded in an ADR, not an implementation discovery.
+
+## See Also
+
+- `patterns/regulated-financial-data-platform.md` — key custody, residency, retention, evidence
+- `patterns/core-banking-data-integration.md` — getting data out of the system of record
+- `patterns/data-platform-selection.md` — choosing and defending a platform
+- `patterns/lakehouse-medallion.md` — the layer pattern in general
+- `general/master-data-management.md` · `patterns/entity-resolution.md` — the identity workstream
+- `general/data-ingestion.md` — CDC, grain, backfill
+- `general/semantic-layer.md` — metric governance and where security is enforced
+- `compliance/ffiec.md` · `compliance/bank-regulatory-reporting.md`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -471,6 +471,7 @@ nav:
     - Data Pipeline: patterns/data-pipeline.md
     - Lakehouse Medallion: patterns/lakehouse-medallion.md
     - Data Platform Selection: patterns/data-platform-selection.md
+    - Regulated FS Reference Architecture: patterns/regulated-fs-reference-architecture.md
     - Entity Resolution: patterns/entity-resolution.md
     - Core Banking Data Integration: patterns/core-banking-data-integration.md
     - Regulated Financial Data Platform: patterns/regulated-financial-data-platform.md


### PR DESCRIPTION
Partly addresses #238, which asks for **worked reference architectures alongside the existing checklists**. This is the first one, in a domain where the stock medallion picture is actively misleading.

`knowledge/patterns/regulated-fs-reference-architecture.md` plus a generated SVG at `knowledge/assets/regulated-fs-data-platform.svg`. `check-nav.sh` passes; `mkdocs build --strict` exits 0.

## Four deliberate departures from a generic lakehouse diagram

Each corresponds to a failure that is expensive to fix after the fact:

**A separate immutable landing zone, distinct from bronze.** A table-format layer is rewritten by compaction and snapshot expiry as routine maintenance, so it cannot carry a retention obligation or a legal hold. Without a landing zone, "we retain everything" is an assertion the storage layer does not support. The page also flags that version-level WORM and hierarchical-namespace accounts interact badly on at least one major cloud — and that the failure is silent, since the policy appears set and does not apply.

**Identity resolution as a workstream, not a box inside the curated layer.** Drawn as a layer it gets estimated as a layer. In a post-merger or multi-source estate it is frequently the largest single body of work in the programme.

**GL reconciliation as an explicit control point.** In an examined institution the acceptance criterion is trust, not latency — a platform producing fast numbers nobody will certify has not delivered.

**A serving layer outside the isolated workspace.** Platform constraints on network isolation routinely make the semantic layer and workspace-level private networking incompatible; discovering that mid-implementation forces a redesign of the consumption tier.

## Notes on how it is written

**Vendor- and institution-neutral.** No product names, no bank. The platform-specific constraints that motivated the pattern are stated generically — "on at least one major platform the semantic-model layer cannot coexist with workspace-level private networking" — so the page does not rot when a vendor ships a fix, and does not read as a swipe at one product.

**The SVG is generated, not drawn**, so it can be regenerated when the pattern changes rather than silently diverging from the prose.

Cross-links to `regulated-financial-data-platform`, `core-banking-data-integration`, `data-platform-selection`, `lakehouse-medallion`, `master-data-management`, `entity-resolution`, `data-ingestion`, `semantic-layer`, `ffiec` and `bank-regulatory-reporting` — all now on master.

Leaving #238 open: it asks for reference architectures plural, and this is one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)